### PR TITLE
create3 implementation for deployment script

### DIFF
--- a/contracts/smart-contract-wallet/deployer/Create3.sol
+++ b/contracts/smart-contract-wallet/deployer/Create3.sol
@@ -1,0 +1,139 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+/**
+  @title A library for deploying contracts EIP-3171 style.
+  @author Agustin Aguilar <aa@horizon.io>
+*/
+library Create3 {
+    error ErrorCreatingProxy();
+    error ErrorCreatingContract();
+    error TargetAlreadyExists();
+
+    /**
+    @notice The bytecode for a contract that proxies the creation of another contract
+    @dev If this code is deployed using CREATE2 it can be used to decouple `creationCode` from the child contract address
+
+  0x67363d3d37363d34f03d5260086018f3:
+      0x00  0x67  0x67XXXXXXXXXXXXXXXX  PUSH8 bytecode  0x363d3d37363d34f0
+      0x01  0x3d  0x3d                  RETURNDATASIZE  0 0x363d3d37363d34f0
+      0x02  0x52  0x52                  MSTORE
+      0x03  0x60  0x6008                PUSH1 08        8
+      0x04  0x60  0x6018                PUSH1 18        24 8
+      0x05  0xf3  0xf3                  RETURN
+
+  0x363d3d37363d34f0:
+      0x00  0x36  0x36                  CALLDATASIZE    cds
+      0x01  0x3d  0x3d                  RETURNDATASIZE  0 cds
+      0x02  0x3d  0x3d                  RETURNDATASIZE  0 0 cds
+      0x03  0x37  0x37                  CALLDATACOPY
+      0x04  0x36  0x36                  CALLDATASIZE    cds
+      0x05  0x3d  0x3d                  RETURNDATASIZE  0 cds
+      0x06  0x34  0x34                  CALLVALUE       val 0 cds
+      0x07  0xf0  0xf0                  CREATE          addr
+  */
+
+    bytes internal constant PROXY_CHILD_BYTECODE =
+        hex"67_36_3d_3d_37_36_3d_34_f0_3d_52_60_08_60_18_f3";
+
+    //                        KECCAK256_PROXY_CHILD_BYTECODE = keccak256(PROXY_CHILD_BYTECODE);
+    bytes32 internal constant KECCAK256_PROXY_CHILD_BYTECODE =
+        0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f;
+
+    /**
+    @notice Returns the size of the code on a given address
+    @param _addr Address that may or may not contain code
+    @return size of the code on the given `_addr`
+  */
+    function codeSize(address _addr) internal view returns (uint256 size) {
+        assembly {
+            size := extcodesize(_addr)
+        }
+    }
+
+    /**
+    @notice Creates a new contract with given `_creationCode` and `_salt`
+    @param _salt Salt of the contract creation, resulting address will be derivated from this value only
+    @param _creationCode Creation code (constructor) of the contract to be deployed, this value doesn't affect the resulting address
+    @return addr of the deployed contract, reverts on error
+  */
+    function create3(
+        bytes32 _salt,
+        bytes memory _creationCode
+    ) internal returns (address addr) {
+        return create3(_salt, _creationCode, 0);
+    }
+
+    /**
+    @notice Creates a new contract with given `_creationCode` and `_salt`
+    @param _salt Salt of the contract creation, resulting address will be derivated from this value only
+    @param _creationCode Creation code (constructor) of the contract to be deployed, this value doesn't affect the resulting address
+    @param _value In WEI of ETH to be forwarded to child contract
+    @return addr of the deployed contract, reverts on error
+  */
+    function create3(
+        bytes32 _salt,
+        bytes memory _creationCode,
+        uint256 _value
+    ) internal returns (address addr) {
+        // Creation code
+        bytes memory creationCode = PROXY_CHILD_BYTECODE;
+
+        // Get target final address
+        addr = addressOf(_salt);
+        if (codeSize(addr) != 0) revert TargetAlreadyExists();
+
+        // Create CREATE2 proxy
+        address proxy;
+        assembly {
+            proxy := create2(
+                0,
+                add(creationCode, 32),
+                mload(creationCode),
+                _salt
+            )
+        }
+        if (proxy == address(0)) revert ErrorCreatingProxy();
+
+        // Call proxy with final init code
+        (bool success, ) = proxy.call{value: _value}(_creationCode);
+        if (!success || codeSize(addr) == 0) revert ErrorCreatingContract();
+    }
+
+    function addressOfProxy(bytes32 _salt) internal view returns (address) {
+        return
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                hex"ff",
+                                address(this),
+                                _salt,
+                                KECCAK256_PROXY_CHILD_BYTECODE
+                            )
+                        )
+                    )
+                )
+            );
+    }
+
+    /**
+    @notice Computes the resulting address of a contract deployed using address(this) and the given `_salt`
+    @param _salt Salt of the contract creation, resulting address will be derivated from this value only
+    @return addr of the deployed contract, reverts on error
+
+    @dev The address creation formula is: keccak256(rlp([keccak256(0xff ++ address(this) ++ _salt ++ keccak256(childBytecode))[12:], 0x01]))
+  */
+    function addressOf(bytes32 _salt) internal view returns (address) {
+        address proxy = addressOfProxy(_salt);
+        return
+            address(
+                uint160(
+                    uint256(
+                        keccak256(abi.encodePacked(hex"d6_94", proxy, hex"01"))
+                    )
+                )
+            );
+    }
+}

--- a/contracts/smart-contract-wallet/deployer/Deployer.sol
+++ b/contracts/smart-contract-wallet/deployer/Deployer.sol
@@ -1,0 +1,17 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "./Create3.sol";
+
+contract Deployer {
+    event ContractDeployed(address indexed contractAddress);
+
+    function deploy(bytes32 _salt, bytes calldata _creationCode) external {
+        address deployedContract = Create3.create3(_salt, _creationCode);
+        emit ContractDeployed(deployedContract);
+    }
+
+    function addressOf(bytes32 _salt) external view returns (address) {
+        return Create3.addressOf(_salt);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "web3": "^1.7.4"
   },
   "dependencies": {
+    "@0xsequence/create3": "https://github.com/0xsequence/create3",
     "@account-abstraction/contracts": "^0.2.0",
     "@chainlink/contracts": "^0.4.1",
     "@ethersproject/abstract-signer": "^5.6.2",

--- a/scripts/entry-point.deploy.ts
+++ b/scripts/entry-point.deploy.ts
@@ -1,11 +1,9 @@
 import { ethers } from "hardhat";
 import {
-  SALT,
-  FACTORY_ADDRESS,
-  getDeployedAddress,
-  deploy,
-  deployFactory,
+  deployContract,
+  DEPLOYMENT_SALTS,
   encodeParam,
+  getDeployerInstance,
   isContract,
 } from "./utils";
 
@@ -17,20 +15,19 @@ async function main() {
   const UNSTAKE_DELAY_SEC = 86400; // update to very high value
   const PAYMASTER_STAKE = ethers.utils.parseEther("1"); // TODO : update to at least 1000$ Note: depends on chain!
 
-  const isFactoryDeployed = await isContract(FACTORY_ADDRESS, provider);
-  if (!isFactoryDeployed) {
-    const deployedFactory = await deployFactory(provider);
-  }
+  const deployerInstance = await getDeployerInstance();
+  const salt = ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(DEPLOYMENT_SALTS.ENTRY_POINT)
+  );
+
 
   const EntryPoint = await ethers.getContractFactory("EntryPoint");
   const entryPointBytecode = `${EntryPoint.bytecode}${encodeParam(
     "uint",
     PAYMASTER_STAKE
   ).slice(2)}${encodeParam("uint32", UNSTAKE_DELAY_SEC).slice(2)}`;
-  const entryPointComputedAddr = getDeployedAddress(
-    entryPointBytecode,
-    ethers.BigNumber.from(SALT)
-  );
+  const entryPointComputedAddr =  await deployerInstance.addressOf(salt);
+
   console.log("Entry Point Computed Address: ", entryPointComputedAddr);
 
   const isEntryPointDeployed = await isContract(
@@ -38,23 +35,13 @@ async function main() {
     provider
   ); // true (deployed on-chain)
   if (!isEntryPointDeployed) {
-    const entryPointDeployedAddr = await deploy(
-      provider,
+    await deployContract(
+      DEPLOYMENT_SALTS.ENTRY_POINT,
+      entryPointComputedAddr,
+      salt,
       entryPointBytecode,
-      ethers.BigNumber.from(SALT)
+      deployerInstance
     );
-
-    console.log("entryPointDeployedAddr ", entryPointDeployedAddr);
-    const entryPointDeploymentStatus =
-      entryPointComputedAddr === entryPointDeployedAddr
-        ? "Deployed Successfully"
-        : false;
-
-    console.log("entryPointDeploymentStatus ", entryPointDeploymentStatus);
-
-    if (!entryPointDeploymentStatus) {
-      console.log("Invalid Entry Point Deployment");
-    }
   } else {
     console.log(
       "Entry Point is Already deployed with address ",

--- a/scripts/paymaster/deploy-singleton.ts
+++ b/scripts/paymaster/deploy-singleton.ts
@@ -1,20 +1,57 @@
 import hre, { ethers } from "hardhat";
+import {
+  deployContract,
+  encodeParam,
+  DEPLOYMENT_SALTS,
+  getDeployerInstance,
+  isContract,
+} from "../utils";
 async function main() {
+
+  const provider = ethers.provider;
+
+  
   const owner = "0x7306aC7A32eb690232De81a9FFB44Bb346026faB";
   const verifyingSigner = "0x416B03E2E5476B6a2d1dfa627B404Da1781e210d";
   const entryPoint = "0x119df1582e0dd7334595b8280180f336c959f3bb";
 
+  const deployerInstance = await getDeployerInstance();
+  const salt = ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(DEPLOYMENT_SALTS.SINGELTON_PAYMASTER)
+  );
+
   const VerifyingSingletonPaymaster = await ethers.getContractFactory(
     "VerifyingSingletonPaymaster"
   );
-  const singletonPaymster = await VerifyingSingletonPaymaster.deploy(
-    entryPoint,
-    owner,
-    verifyingSigner
+  const verifyingSingletonPaymasterBytecode = `${VerifyingSingletonPaymaster.bytecode}${encodeParam(
+    "address",
+    entryPoint
+  ).slice(2)}${encodeParam("address", owner).slice(2)}${encodeParam("address", verifyingSigner).slice(2)}`;
+
+
+  const verifyingSingletonPaymasterComputedAddr = await deployerInstance.addressOf(salt);
+  console.log(
+    "verifyingSingletonPaymaster Handler Computed Address: ",
+    verifyingSingletonPaymasterComputedAddr
   );
-  await singletonPaymster.deployed();
-  console.log("singletonPaymster deployed at: ", singletonPaymster.address);
-}
+  const isContractDeployed = await isContract(
+    verifyingSingletonPaymasterComputedAddr,
+    provider
+  );
+  if (!isContractDeployed) {
+    await deployContract(
+      DEPLOYMENT_SALTS.SINGELTON_PAYMASTER,
+      verifyingSingletonPaymasterComputedAddr,
+      salt,
+      verifyingSingletonPaymasterBytecode,
+      deployerInstance
+    );
+  } else {
+    console.log(
+      "verifyingSingletonPaymaster is Already deployed with address ",
+      verifyingSingletonPaymasterBytecode
+    );
+  }}
 
 main().catch((error) => {
   console.error(error);

--- a/scripts/wallet-factory.deploy.ts
+++ b/scripts/wallet-factory.deploy.ts
@@ -1,11 +1,9 @@
 import { ethers } from "hardhat";
 import {
-  SALT,
-  FACTORY_ADDRESS,
-  getDeployedAddress,
-  deploy,
-  deployFactory,
+  deployContract,
+  DEPLOYMENT_SALTS,
   encodeParam,
+  getDeployerInstance,
   isContract,
 } from "./utils";
 
@@ -14,43 +12,26 @@ const options = { gasLimit: 7000000, gasPrice: 70000000000 };
 async function main() {
   const provider = ethers.provider;
 
-  // const SingletonFactory = await ethers.getContractFactory("SingletonFactory");
-  // const singletonFactory = SingletonFactory.attach(FACTORY_ADDRESS);
-
-  const isFactoryDeployed = await isContract(FACTORY_ADDRESS, provider);
-  if (!isFactoryDeployed) {
-    const deployedFactory = await deployFactory(provider);
-  }
+  const deployerInstance = await getDeployerInstance();
+  const WALLET_FACTORY_IMP_SALT = ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(DEPLOYMENT_SALTS.WALLET_FACTORY_IMP)
+  );
 
   const SmartWallet = await ethers.getContractFactory("SmartWallet");
   const smartWalletBytecode = `${SmartWallet.bytecode}`;
-  const baseImpComputedAddr = getDeployedAddress(
-    smartWalletBytecode,
-    ethers.BigNumber.from(SALT)
-  );
+  const baseImpComputedAddr = await deployerInstance.addressOf(WALLET_FACTORY_IMP_SALT);
   console.log("Base wallet Computed Address: ", baseImpComputedAddr);
 
   let baseImpDeployedAddr;
   const isBaseImpDeployed = await isContract(baseImpComputedAddr, provider); // true (deployed on-chain)
   if (!isBaseImpDeployed) {
-    baseImpDeployedAddr = await deploy(
-      provider,
+    baseImpDeployedAddr = await deployContract(
+      DEPLOYMENT_SALTS.WALLET_FACTORY_IMP,
+      baseImpComputedAddr,
+      WALLET_FACTORY_IMP_SALT,
       smartWalletBytecode,
-      ethers.BigNumber.from(SALT)
-    );
-
-    console.log("baseImpDeployedAddr ", baseImpDeployedAddr);
-    const baseImpDeploymentStatus =
-      baseImpComputedAddr === baseImpDeployedAddr
-        ? "Deployed Successfully"
-        : false;
-
-    console.log("baseImpDeploymentStatus ", baseImpDeploymentStatus);
-
-    if (!baseImpDeploymentStatus) {
-      console.log("Invalid Base Imp Deployment");
-      return;
-    }
+      deployerInstance
+    )
   } else {
     console.log(
       "Base Imp is already deployed with address ",
@@ -60,15 +41,16 @@ async function main() {
   }
   const WalletFactory = await ethers.getContractFactory("WalletFactory");
 
+  const WALLET_FACTORY_SALT = ethers.utils.keccak256(
+    ethers.utils.toUtf8Bytes(DEPLOYMENT_SALTS.WALLET_FACTORY)
+  );
+
   const walletFactoryBytecode = `${WalletFactory.bytecode}${encodeParam(
     "address",
     baseImpDeployedAddr
   ).slice(2)}`;
 
-  const walletFactoryComputedAddr = getDeployedAddress(
-    walletFactoryBytecode,
-    ethers.BigNumber.from(SALT)
-  );
+  const walletFactoryComputedAddr = await deployerInstance.addressOf(WALLET_FACTORY_SALT);
 
   console.log("Wallet Factory Computed Address: ", walletFactoryComputedAddr);
 
@@ -77,24 +59,13 @@ async function main() {
     provider
   ); // true (deployed on-chain)
   if (!iswalletFactoryDeployed) {
-    const walletFactoryDeployedAddr = await deploy(
-      provider,
+    await deployContract(
+      DEPLOYMENT_SALTS.WALLET_FACTORY,
+      walletFactoryComputedAddr,
+      WALLET_FACTORY_SALT,
       walletFactoryBytecode,
-      ethers.BigNumber.from(SALT)
-    );
-
-    const walletFactoryDeploymentStatus =
-      walletFactoryComputedAddr === walletFactoryDeployedAddr
-        ? "Wallet Factory Deployed Successfully"
-        : false;
-    console.log(
-      "walletFactoryDeploymentStatus ",
-      walletFactoryDeploymentStatus
-    );
-
-    if (!walletFactoryDeploymentStatus) {
-      console.log("Invalid Wallet Factory Deployment");
-    }
+      deployerInstance
+    )
   } else {
     console.log(
       "Wallet Factory is Already Deployed with address ",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+"@0xsequence/create3@https://github.com/0xsequence/create3":
+  version "3.0.0"
+  resolved "https://github.com/0xsequence/create3#acc4703a21ec1d71dc2a99db088c4b1f467530fd"
+  dependencies:
+    csv-writer "^1.6.0"
+
 "@account-abstraction/contracts@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@account-abstraction/contracts/-/contracts-0.2.0.tgz#d353fd4b26d8867a3c0067fc0e20da03c99ca2dd"
@@ -3818,6 +3824,11 @@ css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
+csv-writer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/csv-writer/-/csv-writer-1.6.0.tgz#d0cea44b6b4d7d3baa2ecc6f3f7209233514bcf9"
+  integrity sha512-NOx7YDFWEsM/fTRAJjRpPp8t+MKRVvniAg9wQlUKx20MFrPs73WLJhFf5iteqrxNYnsy924K3Iroh3yNHeYd2g==
 
 d@1, d@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR includes create3 implementation for deployment script. Now the smart contract address generation after deployment is not dependent on smart contract code instead deployer address that is msg.sender and salt that we pass would generate deterministic addresses of contracts across multiple chains