### PR TITLE
C4 496 smart account implementation initialization

### DIFF
--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -66,6 +66,7 @@ contract SmartAccount is
         // so we create an account with fixed non-zero owner.
         // This is an unusable account, perfect for the singleton
         owner = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+        _disableInitializers();
     }
 
     

--- a/test/smart-wallet/onboardings-test.ts
+++ b/test/smart-wallet/onboardings-test.ts
@@ -38,7 +38,7 @@ import { provider } from "ganache";
 import { sign } from "crypto";
 
 const GasEstimatorArtifact = artifacts.require("GasEstimator");
-const SCWNoAuth = require("/Users/chirag/work/biconomy/scw-playground/scw-contracts/artifacts/contracts/smart-contract-wallet/SmartAccountNoAuth.sol/SmartAccountNoAuth.json");
+const SCWNoAuth = require("../../artifacts/contracts/smart-contract-wallet/SmartAccountNoAuth.sol/SmartAccountNoAuth.json");
 const GasEstimatorSmartWalletArtifact = artifacts.require(
   "GasEstimatorSmartAccount"
 );


### PR DESCRIPTION
Added _disableInitializers() to constructor.

Decided not to add signer != address(0) check in checkSignatures as it will add extra gas for every signature verification.
In general, for actual user wallets, there will never be address(0) as owner, so no danger here.

Btw, it can be interesting to redesign the full proxy deployment and initialization flow according to https://github.com/code-423n4/2023-01-biconomy-findings/blob/main/data/0xSmartContract-G.md#g-02-remove-the-initializer-modifier
it can make new scw deployment cheaper