### PR TITLE
Controlled erc20 token transfers unification

### DIFF
--- a/contracts/smart-contract-wallet/MaliciousAccount.sol
+++ b/contracts/smart-contract-wallet/MaliciousAccount.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.12;
 
 import "./libs/LibAddress.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "./BaseSmartAccount.sol";
 import "./common/Singleton.sol";
@@ -11,6 +9,7 @@ import "./base/ModuleManager.sol";
 import "./base/FallbackManager.sol";
 import "./common/SignatureDecoder.sol";
 import "./common/SecuredTokenTransfer.sol";
+import {SmartAccountErrors} from "./common/Errors.sol";
 import "./interfaces/ISignatureValidator.sol";
 import "./interfaces/IERC165.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -25,7 +24,8 @@ contract MaliciousAccount is
      ISignatureValidatorConstants,
      FallbackManager,
      Initializable,
-     ReentrancyGuardUpgradeable
+     ReentrancyGuardUpgradeable,
+     SmartAccountErrors
     {
     using ECDSA for bytes32;
     using LibAddress for address;
@@ -452,8 +452,7 @@ contract MaliciousAccount is
     }
 
     function pullTokens(address token, address dest, uint256 amount) external onlyOwner {
-        IERC20 tokenContract = IERC20(token);
-        SafeERC20.safeTransfer(tokenContract, dest, amount);
+        if (!transferToken(token, dest, amount)) revert TokenTransferFailed(token, dest, amount);
     }
 
     function execute(address dest, uint value, bytes calldata func) external onlyOwner{

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.12;
 
 import "./libs/LibAddress.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "./BaseSmartAccount.sol";
 import "./common/Singleton.sol";
@@ -11,6 +9,7 @@ import "./base/ModuleManager.sol";
 import "./base/FallbackManager.sol";
 import "./common/SignatureDecoder.sol";
 import "./common/SecuredTokenTransfer.sol";
+import {SmartAccountErrors} from "./common/Errors.sol";
 import "./interfaces/ISignatureValidator.sol";
 import "./interfaces/IERC165.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -25,7 +24,8 @@ contract SmartAccount is
      ISignatureValidatorConstants,
      FallbackManager,
      Initializable,
-     ReentrancyGuardUpgradeable
+     ReentrancyGuardUpgradeable,
+     SmartAccountErrors
     {
     using ECDSA for bytes32;
     using LibAddress for address;
@@ -472,8 +472,7 @@ contract SmartAccount is
     }
 
     function pullTokens(address token, address dest, uint256 amount) external onlyOwner {
-        IERC20 tokenContract = IERC20(token);
-        SafeERC20.safeTransfer(tokenContract, dest, amount);
+        if (!transferToken(token, dest, amount)) revert TokenTransferFailed(token, dest, amount);
     }
 
     function execute(address dest, uint value, bytes calldata func) external onlyOwner{

--- a/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
+++ b/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.12;
 
 import "./libs/LibAddress.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "./BaseSmartAccount.sol";
 import "./common/Singleton.sol";
@@ -11,6 +9,7 @@ import "./base/ModuleManager.sol";
 import "./base/FallbackManager.sol";
 import "./common/SignatureDecoder.sol";
 import "./common/SecuredTokenTransfer.sol";
+import {SmartAccountErrors} from "./common/Errors.sol";
 import "./interfaces/ISignatureValidator.sol";
 import "./interfaces/IERC165.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -25,7 +24,8 @@ contract SmartAccountNoAuth is
      ISignatureValidatorConstants,
      FallbackManager,
      Initializable,
-     ReentrancyGuardUpgradeable
+     ReentrancyGuardUpgradeable,
+     SmartAccountErrors
     {
     using ECDSA for bytes32;
     using LibAddress for address;
@@ -452,8 +452,7 @@ contract SmartAccountNoAuth is
     }
 
     function pullTokens(address token, address dest, uint256 amount) external onlyOwner {
-        IERC20 tokenContract = IERC20(token);
-        SafeERC20.safeTransfer(tokenContract, dest, amount);
+        if (!transferToken(token, dest, amount)) revert TokenTransferFailed(token, dest, amount);
     }
 
     function execute(address dest, uint value, bytes calldata func) external onlyOwner{

--- a/contracts/smart-contract-wallet/common/Errors.sol
+++ b/contracts/smart-contract-wallet/common/Errors.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.12;
+
+contract SmartAccountErrors {
+    error TokenTransferFailed(address token, address dest, uint256 amount);
+}
+
+
+//


### PR DESCRIPTION
Removed OZ/SafeERC20 and replaced it with SecuredTokenTransfer and revert + custom error
introduced contract for custom errors since it was one of the qa/gas recommendations so we will switch to custom errors anyways
