### PR TITLE
C4 154 Remove Receive() function

### DIFF
--- a/contracts/smart-contract-wallet/Proxy.sol
+++ b/contracts/smart-contract-wallet/Proxy.sol
@@ -33,8 +33,4 @@ contract Proxy {
         }
     }
 
-    receive() external payable {
-        emit Received(msg.value, msg.sender, "");
-    }
-
 }

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -76,6 +76,7 @@ contract SmartAccount is
     event EntryPointChanged(address oldEntryPoint, address newEntryPoint);
     event EOAChanged(address indexed _scw, address indexed _oldEOA, address indexed _newEOA);
     event WalletHandlePayment(bytes32 txHash, uint256 payment);
+    event SmartAccountReceivedNativeToken(address indexed sender, uint256 value);
     // nice to have
     // event SmartAccountInitialized(IEntryPoint indexed entryPoint, address indexed owner);
     // todo
@@ -565,5 +566,7 @@ contract SmartAccount is
     }
 
     // solhint-disable-next-line no-empty-blocks
-    receive() external payable {}
+    receive() external payable {
+        emit SmartAccountReceivedNativeToken(msg.sender, msg.value);
+    }
 }

--- a/test/smart-wallet/testGroup1.ts
+++ b/test/smart-wallet/testGroup1.ts
@@ -136,11 +136,16 @@ describe("Base Wallet Functionality", function () {
     console.log("walletNonce2 ", walletNonce2);
     console.log("chainId ", chainId);
 
-    await accounts[1].sendTransaction({
+    const tx = await accounts[1].sendTransaction({
       from: bob,
       to: expected,
       value: ethers.utils.parseEther("5"),
     });
+
+    await expect(tx)
+      .to.emit(userSCW, 'SmartAccountReceivedNativeToken')
+      .withArgs(bob, ethers.utils.parseEther("5"));
+
   });
 
   // Transactions


### PR DESCRIPTION
* Removed receive() from proxy
* Can't remove from implementation as it has no payable fallback
* https://github.com/safe-global/safe-contracts/blob/main/contracts/common/EtherPaymentFallback.sol 
* Added event `SmartAccountReceivedNativeToken` to track incoming native token payments