### PR TITLE
BSDK-362 Enable value transfer using executeBatch

### DIFF
--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -463,16 +463,21 @@ contract SmartAccount is
         SafeERC20.safeTransfer(tokenContract, dest, amount);
     }
 
-    function execute(address dest, uint value, bytes calldata func) external onlyOwner{
+    function executeCall(address dest, uint256 value, bytes calldata func) external {
         _requireFromEntryPointOrOwner();
         _call(dest, value, func);
     }
 
-    function executeBatch(address[] calldata dest, bytes[] calldata func) external onlyOwner{
+    function executeBatchCall(
+        address[] calldata dest,
+        uint256[] calldata value,
+        bytes[] calldata func
+    ) external {
         _requireFromEntryPointOrOwner();
-        require(dest.length == func.length, "wrong array lengths");
-        for (uint i = 0; i < dest.length;) {
-            _call(dest[i], 0, func[i]);
+        require(dest.length == value.length, "wrong array lengths");
+        require(value.length == func.length, "wrong array lengths");
+        for (uint256 i = 0; i < dest.length; ) {
+            _call(dest[i], value[i], func[i]);
             unchecked {
                 ++i;
             }
@@ -488,7 +493,7 @@ contract SmartAccount is
             }
         }
     }
-    
+
     //called by entryPoint, only after validateUserOp succeeded.
     //@review
     //Method is updated to instruct delegate call and emit regular events

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -463,7 +463,11 @@ contract SmartAccount is
         SafeERC20.safeTransfer(tokenContract, dest, amount);
     }
 
-    function executeCall(address dest, uint256 value, bytes calldata func) external {
+    function executeCall(
+        address dest,
+        uint256 value,
+        bytes calldata func
+    ) external nonReentrant {
         _requireFromEntryPointOrOwner();
         _call(dest, value, func);
     }
@@ -472,7 +476,7 @@ contract SmartAccount is
         address[] calldata dest,
         uint256[] calldata value,
         bytes[] calldata func
-    ) external {
+    ) external nonReentrant {
         _requireFromEntryPointOrOwner();
         require(dest.length == value.length, "wrong array lengths");
         require(value.length == func.length, "wrong array lengths");

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -478,6 +478,7 @@ contract SmartAccount is
         bytes[] calldata func
     ) external nonReentrant {
         _requireFromEntryPointOrOwner();
+        require(dest.length != 0, "empty array provided");
         require(dest.length == value.length, "wrong array lengths");
         require(value.length == func.length, "wrong array lengths");
         for (uint256 i = 0; i < dest.length; ) {

--- a/test/smart-wallet/testGroup1.ts
+++ b/test/smart-wallet/testGroup1.ts
@@ -202,6 +202,10 @@ describe("Base Wallet Functionality", function () {
     expect(await ethers.provider.getBalance(charlie)).to.equal(
       charlieBalBefore.add(ethers.utils.parseEther("1"))
     );
+
+    // test with empty array data and value
+    tx = userSCW.connect(accounts[0]).executeBatchCall([], [], []);
+    expect(tx).to.be.revertedWith("empty array provided");
   });
 
   it("should send transactions in a batch", async function () {

--- a/test/smart-wallet/testGroup1.ts
+++ b/test/smart-wallet/testGroup1.ts
@@ -143,33 +143,64 @@ describe("Base Wallet Functionality", function () {
   });
 
   // Transactions
-  it("Should send basic transactions from SCW to external contracts", async function () {
+  it("Should send basic erc20 transactions from SCW to external contracts", async function () {
     console.log("sending tokens to the safe..");
     await token
       .connect(accounts[0])
       .transfer(userSCW.address, ethers.utils.parseEther("100"));
 
+    // test for executeCall method with erc20 transfer
     const data = encodeTransfer(bob, ethers.utils.parseEther("10").toString());
-    const tx = await userSCW
+    let tx = await userSCW
       .connect(accounts[0])
-      .execute(token.address, ethers.utils.parseEther("0"), data);
-    const receipt = await tx.wait();
-    console.log(receipt.transactionHash);
-
+      .executeCall(token.address, ethers.utils.parseEther("0"), data);
+    await tx.wait();
     expect(await token.balanceOf(bob)).to.equal(ethers.utils.parseEther("10"));
 
-    // executeBatch
+    // test for executeBatchCall method with erc20 transfer
     const data2 = encodeTransfer(
       charlie,
       ethers.utils.parseEther("10").toString()
     );
-    await userSCW
+    tx = await userSCW
       .connect(accounts[0])
-      .executeBatch([token.address, token.address], [data, data2]);
+      .executeBatchCall([token.address, token.address], [0, 0], [data, data2]);
+    await tx.wait();
 
     expect(await token.balanceOf(bob)).to.equal(ethers.utils.parseEther("20"));
     expect(await token.balanceOf(charlie)).to.equal(
       ethers.utils.parseEther("10")
+    );
+  });
+
+  it("Should send basic native eth transactions from SCW to external contracts", async function () {
+    console.log("sending native tokens to bob charlie..");
+
+    // test for executeCall method with native value transfer
+    const bobBalBefore = await ethers.provider.getBalance(bob);
+    let tx = await userSCW
+      .connect(accounts[0])
+      .executeCall(bob, ethers.utils.parseEther("1"), "0x");
+    await tx.wait();
+    expect(await ethers.provider.getBalance(bob)).to.equal(
+      bobBalBefore.add(ethers.utils.parseEther("1"))
+    );
+
+    // executeBatchCall method with native value transfer
+    const charlieBalBefore = await ethers.provider.getBalance(charlie);
+    tx = await userSCW
+      .connect(accounts[0])
+      .executeBatchCall(
+        [bob, charlie],
+        [ethers.utils.parseEther("1"), ethers.utils.parseEther("1")],
+        ["0x", "0x"]
+      );
+    await tx.wait();
+    expect(await ethers.provider.getBalance(bob)).to.equal(
+      bobBalBefore.add(ethers.utils.parseEther("2"))
+    );
+    expect(await ethers.provider.getBalance(charlie)).to.equal(
+      charlieBalBefore.add(ethers.utils.parseEther("1"))
     );
   });
 


### PR DESCRIPTION
- pass array of values in executeBatch function and remove hardcoded 0 in _call() function. use values[i] instead.

- rename execute method name which conflicts the internal execute method in Executor.sol

- while doing this, also remove onlyOwner modifier on execute() and executeBatch() functions(search 495 - execute() and executeBatch() functions in SmartAccount.sol from the EntryPoint will fail ) in mid risk page

- also combining this here: #313 making sure above functions and any other function that can have reentrancy uses non-reentrant modifier.