### PR TITLE
making proxy and wallet factory lighter 

### DIFF
--- a/test/smart-wallet/gasEstimations.ts
+++ b/test/smart-wallet/gasEstimations.ts
@@ -165,8 +165,8 @@ describe("Wallet tx gas estimations with and without refunds", function () {
     console.log("deploying new wallet..expected address: ", expected);
 
     await expect(walletFactory.deployCounterFactualWallet(owner, indexForSalt))
-      .to.emit(walletFactory, "SmartAccountCreated")
-      .withArgs(expected, baseImpl.address, owner, "1.0.4", indexForSalt);
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, baseImpl.address);
 
     userSCW = await ethers.getContractAt(
       "contracts/smart-contract-wallet/SmartAccount.sol:SmartAccount",

--- a/test/smart-wallet/proxy-deploy.ts
+++ b/test/smart-wallet/proxy-deploy.ts
@@ -41,8 +41,15 @@ describe("Wallet Deployment", function () {
     );
     console.log("deploying new wallet..expected address: ", expected);
 
-    await expect(walletFactory.deployCounterFactualWallet(owner, indexForSalt))
-      .to.emit(walletFactory, "SmartAccountCreated")
-      .withArgs(expected, baseImpl.address, owner, "1.0.4", 0);
+    const tx = await walletFactory.deployCounterFactualWallet(
+      owner,
+      indexForSalt
+    );
+    const receipt = await tx.wait();
+    console.log("smart account deployment gas ", receipt.gasUsed.toNumber());
+
+    /* await expect(walletFactory.deployCounterFactualWallet(owner, indexForSalt))
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, baseImpl.address); */
   });
 });

--- a/test/smart-wallet/refund-estimation.ts
+++ b/test/smart-wallet/refund-estimation.ts
@@ -174,8 +174,8 @@ describe("Wallet tx gas estimations with and without refunds", function () {
     console.log("deploying new wallet..expected address: ", expected);
 
     await expect(walletFactory.deployCounterFactualWallet(owner, indexForSalt))
-      .to.emit(walletFactory, "SmartAccountCreated")
-      .withArgs(expected, baseImpl.address, owner, "1.0.4", indexForSalt);
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, baseImpl.address);
 
     userSCW = await ethers.getContractAt(
       "contracts/smart-contract-wallet/SmartAccount.sol:SmartAccount",

--- a/test/smart-wallet/testGroup1.ts
+++ b/test/smart-wallet/testGroup1.ts
@@ -114,8 +114,8 @@ describe("Base Wallet Functionality", function () {
     console.log("deploying new wallet..expected address: ", expected);
 
     await expect(walletFactory.deployCounterFactualWallet(owner, indexForSalt))
-      .to.emit(walletFactory, "SmartAccountCreated")
-      .withArgs(expected, baseImpl.address, owner, VERSION, indexForSalt);
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, baseImpl.address);
 
     userSCW = await ethers.getContractAt(
       "contracts/smart-contract-wallet/SmartAccount.sol:SmartAccount",
@@ -143,9 +143,8 @@ describe("Base Wallet Functionality", function () {
     });
 
     await expect(tx)
-      .to.emit(userSCW, 'SmartAccountReceivedNativeToken')
+      .to.emit(userSCW, "SmartAccountReceivedNativeToken")
       .withArgs(bob, ethers.utils.parseEther("5"));
-
   });
 
   // Transactions
@@ -242,11 +241,9 @@ describe("Base Wallet Functionality", function () {
     let signature = "0x";
     signature += data.slice(2);
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     await expect(
@@ -310,11 +307,9 @@ describe("Base Wallet Functionality", function () {
     signature += data.slice(2);
 
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
@@ -364,17 +359,15 @@ describe("Base Wallet Functionality", function () {
     let signature = "0x";
     signature += data.slice(2);
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.be.reverted;
 
     expect(await token.balanceOf(charlie)).to.equal(
       ethers.utils.parseEther("0")
     );
-  }); 
+  });
 
   it("Can not execute txn with the same nonce twice", async function () {
     await token
@@ -417,11 +410,9 @@ describe("Base Wallet Functionality", function () {
     signature += data.slice(2);
 
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
@@ -429,18 +420,15 @@ describe("Base Wallet Functionality", function () {
     );
 
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.be.reverted;
 
     expect(await token.balanceOf(charlie)).to.equal(
       ethers.utils.parseEther("10")
     );
-
-  }); 
+  });
 
   it("should send two consecutive transactions with the correct nonces and they go through)", async function () {
     await token
@@ -462,7 +450,7 @@ describe("Base Wallet Functionality", function () {
       chainId
     );
 
-    //console.log(safeTx);
+    // console.log(safeTx);
 
     const transaction: Transaction = {
       to: safeTx.to,
@@ -482,11 +470,9 @@ describe("Base Wallet Functionality", function () {
     let signature = "0x";
     signature += data.slice(2);
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
@@ -500,12 +486,12 @@ describe("Base Wallet Functionality", function () {
       nonce: await userSCW.getNonce(EOA_CONTROLLED_FLOW),
     });
 
-    ( { signer, data } = await safeSignTypedData(
+    ({ signer, data } = await safeSignTypedData(
       accounts[0],
       userSCW,
       safeTx2,
       chainId
-    ) );
+    ));
 
     const transaction2: Transaction = {
       to: safeTx2.to,
@@ -519,17 +505,14 @@ describe("Base Wallet Functionality", function () {
     signature += data.slice(2);
 
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction2,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction2, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
       ethers.utils.parseEther("21")
     );
-
   });
 
   it("should send a single transacton (personal sign)", async function () {
@@ -571,11 +554,9 @@ describe("Base Wallet Functionality", function () {
     let signature = "0x";
     signature += data.slice(2);
     await expect(
-      userSCW.connect(accounts[0]).execTransaction(
-        transaction,
-        refundInfo,
-        signature
-      )
+      userSCW
+        .connect(accounts[0])
+        .execTransaction(transaction, refundInfo, signature)
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
@@ -647,12 +628,11 @@ describe("Base Wallet Functionality", function () {
     };
 
     await expect(
-      userSCW.connect(accounts[1]).execTransaction(
-        transaction,
-        refundInfo,
-        signature,
-        { gasPrice: safeTx.gasPrice }
-      )
+      userSCW
+        .connect(accounts[1])
+        .execTransaction(transaction, refundInfo, signature, {
+          gasPrice: safeTx.gasPrice,
+        })
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(
@@ -723,12 +703,11 @@ describe("Base Wallet Functionality", function () {
     };
 
     await expect(
-      userSCW.connect(accounts[1]).execTransaction(
-        transaction,
-        refundInfo,
-        signature,
-        { gasPrice: safeTx.gasPrice }
-      )
+      userSCW
+        .connect(accounts[1])
+        .execTransaction(transaction, refundInfo, signature, {
+          gasPrice: safeTx.gasPrice,
+        })
     ).to.emit(userSCW, "ExecutionSuccess");
 
     expect(await token.balanceOf(charlie)).to.equal(

--- a/test/smart-wallet/vulnerabilityTests.ts
+++ b/test/smart-wallet/vulnerabilityTests.ts
@@ -116,8 +116,8 @@ describe("Vulnerability tests", function () {
     );
 
     await expect(walletFactory.deployCounterFactualWallet(owner, 0))
-      .to.emit(walletFactory, "SmartAccountCreated")
-      .withArgs(expected, baseImpl.address, owner, VERSION, 0);
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, baseImpl.address);
 
     userSCW = await ethers.getContractAt(
       "contracts/smart-contract-wallet/SmartAccount.sol:SmartAccount",


### PR DESCRIPTION
Making proxy and wallet factory lighter  ( commit for review & chat + dev notes )

couple of things to discuss here which I put in dev notes as well (final code will be cleaned up)

**Proxy.sol**

- removed EIP1967 storage slot
- commented out singleton to be at 0th storage slot (gnosis uses this way to fetch the target)
- storing singleton (base implementation / accountLogic / singleton) at storage slot given by address() opcode [ maybe we should pick one name from above three and use through out ]
- removed receive event as it doesn't make sense here 
- added accountLogic read method to query the implementation address on proxy 


** SmartAccountFactory.sol **

- added read method accountCreationCode to get the creation code of Proxy
- changed unit -> unit256
- isAccountExist is commented out for now it's unnecessary state management unless we absolutely need it
- commented out VERSION as versions can conflict with smart account implementation contract versioning [ we can emit an event under initialise to do version tracking ] 
- commented event SmartAccountCreated. added AccountCreation (which may also emit owner and index. but above event inside init can do that as well)


open for discussion (comparison with Safe factory and others)

- need of constructor
- versioning plans if constructor args changes
- if constructor is removed _implementation address can be part of function args. [goes well with not keeping version variable in factory]
- todo : rename wallet to account
- possibility of sending initialiser also as another deploy function (create2) but that would require another read method too to get counterfactual address

