### PR TITLE
add freedom for module to validate userOpHash + dev notes

### DIFF
--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -11,6 +11,7 @@ import {IERC165} from "./interfaces/IERC165.sol";
 import {SmartAccountErrors} from "./common/Errors.sol";
 import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/ISignatureValidator.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IModule} from "./test/IModule.sol";
 
 contract SmartAccount is
     BaseSmartAccount,
@@ -796,7 +797,8 @@ contract SmartAccount is
                     userOpData[4:],
                     (address, uint, bytes)
                 );
-                if (address(modules[_to]) != address(0)) return 0;
+                if (address(modules[_to]) != address(0))
+                    return IModule(_to).validateSignature(userOp, userOpHash);
             }
         }
         bytes32 hash = userOpHash.toEthSignedMessageHash();

--- a/contracts/smart-contract-wallet/test/IModule.sol
+++ b/contracts/smart-contract-wallet/test/IModule.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+
+// interface for modules to verify singatures signed over userOpHash
+interface IModule {
+    /**
+     * @dev standard validateSignature for modules to validate and mark userOpHash as seen
+     * @param userOp the operation that is about to be executed.
+     * @param userOpHash hash of the user's request data. can be used as the basis for signature.
+     * @return sigValidationResult sigAuthorizer to be passed back to trusting Account, aligns with validationData
+     */
+    function validateSignature(
+        UserOperation calldata userOp,
+        bytes32 userOpHash
+    ) external returns (uint256 sigValidationResult);
+}

--- a/contracts/smart-contract-wallet/test/WhitelistModule.sol
+++ b/contracts/smart-contract-wallet/test/WhitelistModule.sol
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.17;
 import "../SmartAccount.sol";
+import {IModule} from "./IModule.sol";
 
 contract WhitelistModule {
     mapping(address => bool) public whitelisted;
     address public moduleOwner;
+    uint256 internal constant SIG_VALIDATION_FAILED = 1;
+
+    // @review
+    // Might as well keep a state to mark seen userOpHashes
+    mapping(bytes32 => bool) public opsSeen;
+
+    // @todo
+    // Notice validateAndUpdateNonce in just skipped in case of modules. To avoid replay of same userOpHash I think it should be done.
 
     constructor(address _owner) {
         moduleOwner = _owner;
@@ -21,6 +30,22 @@ contract WhitelistModule {
             "Destination target can not be zero address"
         );
         whitelisted[_target] = true;
+    }
+
+    /**
+     * @dev standard validateSignature for modules to validate and mark userOpHash as seen
+     * @param userOp the operation that is about to be executed.
+     * @param userOpHash hash of the user's request data. can be used as the basis for signature.
+     * @return sigValidationResult sigAuthorizer to be passed back to trusting Account, aligns with validationData
+     */
+    function validateSignature(
+        UserOperation calldata userOp,
+        bytes32 userOpHash
+    ) external virtual returns (uint256 sigValidationResult) {
+        if (opsSeen[userOpHash] == true) return SIG_VALIDATION_FAILED;
+        opsSeen[userOpHash] = true;
+        // can perform it's own access control logic, verify agaisnt expected signer and return SIG_VALIDATION_FAILED
+        return 0;
     }
 
     function authCall(

--- a/test/module/aa-module.specs.ts
+++ b/test/module/aa-module.specs.ts
@@ -605,6 +605,7 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
       console.log(userOp);
+      // const userOpHash = await entryPoint.getUserOpHash(userOp);
       await entryPoint.handleOps([userOp], await offchainSigner.getAddress(), {
         gasLimit: 10000000,
       });


### PR DESCRIPTION
added below IModule method

```
 function validateSignature(
        UserOperation calldata userOp,
        bytes32 userOpHash
    ) external returns (uint256 sigValidationResult);
```

Now modules implement this interface. WhitelistModule and SocialRecoveryModule implements this method to just return zero. they also have a constant SIG_VALIDATION_FAILED in case they need to reject signature. 

Another thing I believe modules should have is ability to mark hashes as processed/seen, as there is no inherent nonce protection to prevent from same signature being used again (unless of course you define custom nonce and struct in typehash of it's own) 

Same interface is referenced in SmartAccount to call module.validateSignature(userOp, userOpHash)


- one thing I haven't done which can possibly go in this branch is checking userOp against userOpHash


also still following up to understand more over here https://github.com/eth-infinitism/account-abstraction/issues/237 and on dms.