### PR TITLE
Custom Reentrancy Guard + update to GuardManager test cases

### DIFF
--- a/contracts/smart-contract-wallet/BaseSmartAccount.sol
+++ b/contracts/smart-contract-wallet/BaseSmartAccount.sol
@@ -23,7 +23,7 @@ struct Transaction {
 struct FeeRefund {
     uint256 baseGas;
     uint256 gasPrice; //gasPrice or tokenGasPrice
-    uint256 tokenGasPriceFactor;
+    uint256 tokenGasPriceFactor; 
     address gasToken;
     address payable refundReceiver;
 }

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -7,9 +7,10 @@ import {FallbackManager} from "./base/FallbackManager.sol";
 import {SignatureDecoder} from "./common/SignatureDecoder.sol";
 import {SecuredTokenTransfer} from "./common/SecuredTokenTransfer.sol";
 import {LibAddress} from "./libs/LibAddress.sol";
-import {IERC165} from "./interfaces/IERC165.sol";
-import {SmartAccountErrors} from "./common/Errors.sol";
 import {ISignatureValidator, ISignatureValidatorConstants} from "./interfaces/ISignatureValidator.sol";
+import {IERC165} from "./interfaces/IERC165.sol";
+import {ReentrancyGuard} from "./common/ReentrancyGuard.sol";
+import {SmartAccountErrors} from "./common/Errors.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract SmartAccount is
@@ -20,13 +21,13 @@ contract SmartAccount is
     SecuredTokenTransfer,
     ISignatureValidatorConstants,
     IERC165,
+    ReentrancyGuard,
     SmartAccountErrors
 {
     using ECDSA for bytes32;
     using LibAddress for address;
 
     // Storage
-
     // Version
     string public constant VERSION = "1.0.4"; // using AA 0.4.0
 
@@ -262,7 +263,7 @@ contract SmartAccount is
         Transaction memory _tx,
         FeeRefund memory refundInfo,
         bytes memory signatures
-    ) public payable virtual returns (bool success) {
+    ) public payable virtual nonReentrant() returns (bool success) {
         uint256 startGas = gasleft();
         bytes32 txHash;
         // Use scope here to limit variable lifetime and prevent `stack too deep` errors

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -237,7 +237,6 @@ contract SmartAccount is
         if (_owner == address(0)) revert OwnerCannotBeZero();
         owner = _owner;
         _setFallbackHandler(_handler);
-        address factory = msg.sender;
         // can be emitted owner, entryPoint, VERSION, handler
         _setupModules(address(0), bytes(""));
     }

--- a/contracts/smart-contract-wallet/common/ReentrancyGuard.sol
+++ b/contracts/smart-contract-wallet/common/ReentrancyGuard.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.17;
+
+/// @title Reentrancy Guard - reentrancy protection
+abstract contract ReentrancyGuard {
+
+    error ReentrancyProtectionActivated();
+    
+    uint256 private constant NOT_ENTERED = 1;
+    uint256 private constant ENTERED = 2;
+
+    uint256 private reentrancyStatus;
+
+    constructor() {
+        reentrancyStatus = NOT_ENTERED;
+    }
+
+    modifier nonReentrant() {
+        if(reentrancyStatus == ENTERED) revert ReentrancyProtectionActivated();
+        reentrancyStatus = ENTERED;
+        _;
+        reentrancyStatus = NOT_ENTERED;
+    }
+
+    function _isReentrancyGuardEntered() internal view returns (bool) {
+        return reentrancyStatus == ENTERED;
+    }
+}

--- a/contracts/smart-contract-wallet/libs/SmartAccountStorage.sol
+++ b/contracts/smart-contract-wallet/libs/SmartAccountStorage.sol
@@ -11,6 +11,8 @@ contract SmartAccountStorage {
 
     uint256[24] private __fallbackManagerGap;
 
+    uint256 private reentrancyStatus;
+
     // Smart Account Storage
     address internal owner;
 

--- a/contracts/smart-contract-wallet/test/TestIncreaseNonceLib.sol
+++ b/contracts/smart-contract-wallet/test/TestIncreaseNonceLib.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "../libs/SmartAccountStorage.sol";
+import "../SmartAccount.sol";
+
+/// @title TestIncreaseNonceLib - Test Lib to Increase Nonce
+/// @notice used to test delegatecalls from Smart Account
+contract TestIncreaseNonceLib is SmartAccountStorage {
+    
+    event NonceIncreasedFromLib(uint256 batchId, uint256 newNonce);
+
+    function increaseNonce(uint256 batchId) external {
+        emit NonceIncreasedFromLib(batchId, ++nonces[batchId]);
+    }
+    
+}

--- a/contracts/smart-contract-wallet/test/upgrades/Guards/DelegateCallTransactionGuard.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/Guards/DelegateCallTransactionGuard.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.17;
+
+import {Enum} from "../../../common/Enum.sol";
+import {BaseGuard} from "./GuardManager.sol";
+import {Transaction, FeeRefund} from "../../../BaseSmartAccount.sol";
+
+contract DelegateCallTransactionGuard is BaseGuard {
+
+    error DelegateCallGuardRestricted();
+
+    address public immutable allowedTarget;
+
+    constructor(address target) {
+        allowedTarget = target;
+    }
+
+    // solhint-disable-next-line payable-fallback
+    fallback() external {
+        // We don't revert on fallback to avoid issues in case of a SmartAccount upgrade
+        // E.g. The expected check method might change and then the Smart Account would be locked.
+    }
+
+    function checkTransaction(
+        Transaction memory _tx,
+        FeeRefund memory,
+        bytes memory,
+        address
+    ) external view override {
+        if(_tx.operation == Enum.Operation.DelegateCall && _tx.to != allowedTarget) revert DelegateCallGuardRestricted();
+    }
+
+    function checkAfterExecution(bytes32, bool) external view override {}
+}

--- a/contracts/smart-contract-wallet/test/upgrades/Guards/GuardManager.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/Guards/GuardManager.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.17;
+
+import {Enum} from "../../../common/Enum.sol";
+import {Transaction, FeeRefund} from "../../../BaseSmartAccount.sol";
+import {SelfAuthorized} from "../../../common/SelfAuthorized.sol";
+import {IERC165} from "../../../interfaces/IERC165.sol";
+
+interface Guard is IERC165 {
+
+    function checkTransaction(
+        Transaction memory _tx,
+        FeeRefund memory refundInfo,
+        bytes memory signatures,
+        address msgSender
+    ) external;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external;
+}
+
+abstract contract BaseGuard is Guard {
+    function supportsInterface(bytes4 interfaceId) external view virtual override returns (bool) {
+        return
+            interfaceId == type(Guard).interfaceId || // 0xe6d7a83a
+            interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
+    }
+}
+
+/// @title Guard Manager - A contract that manages transaction guards which perform pre and post-checks on execution by multisig owners
+/// @author Inspired by Richard Meissner's <richard@gnosis.pm> implementation
+contract GuardManager is SelfAuthorized {
+    event GuardChanged(address guard);
+    error InvalidGuard(address guard);
+    // keccak256("guard_manager.guard.address")
+    bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    /// @dev Set a guard that checks transactions before execution
+    /// @param guard The address of the guard to be used or the 0 address to disable the guard
+    function setGuard(address guard) external authorized {
+        if (guard != address(0)) {
+            if(!Guard(guard).supportsInterface(type(Guard).interfaceId))  revert InvalidGuard(guard);
+        }
+        bytes32 slot = GUARD_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(slot, guard)
+        }
+        emit GuardChanged(guard);
+    }
+
+    function getGuard() public view returns (address guard) {
+        bytes32 slot = GUARD_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            guard := sload(slot)
+        }
+    }
+}

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
@@ -7,6 +7,7 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount10 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
@@ -7,6 +7,7 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount11 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount12Guard.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount12Guard.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "../../SmartAccount.sol";
+import {GuardManager, Guard} from "./Guards/GuardManager.sol";
+import "hardhat/console.sol";
+
+contract SmartAccount12Guard is SmartAccount, GuardManager {
+
+    constructor(IEntryPoint anEntryPoint) SmartAccount(anEntryPoint) {}
+
+    function execTransaction_S6W(
+        Transaction memory _tx,
+        FeeRefund memory refundInfo,
+        bytes memory signatures
+    ) public payable virtual override nonReentrant() returns (bool success) {
+        uint256 startGas = gasleft();
+        bytes32 txHash;
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            bytes memory txHashData = encodeTransactionData(
+                // Transaction info
+                _tx,
+                // Payment info
+                refundInfo,
+                // Signature info
+                nonces[1]++
+            );
+            txHash = keccak256(txHashData);
+            checkSignatures(txHash, signatures);
+        }
+
+        address guard = getGuard();
+        {
+            if (guard != address(0)) {
+                Guard(guard).checkTransaction(
+                    _tx,
+                    refundInfo,
+                    signatures,
+                    msg.sender
+                );
+            }
+        }
+
+        // We require some gas to emit the events (at least 2500) after the execution and some to perform code until the execution (500)
+        // We also include the 1/64 in the check that is not send along with a call to counteract potential shortings because of EIP-150
+        // Bitshift left 6 bits means multiplying by 64, just more gas efficient
+        if (
+            gasleft() <
+            max((_tx.targetTxGas << 6) / 63, _tx.targetTxGas + 2500) + 500
+        )
+            revert NotEnoughGasLeft(
+                gasleft(),
+                max((_tx.targetTxGas << 6) / 63, _tx.targetTxGas + 2500) + 500
+            );
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            // If the gasPrice is 0 we assume that nearly all available gas can be used (it is always more than targetTxGas)
+            // We only substract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than targetTxGas
+            success = execute(
+                _tx.to,
+                _tx.value,
+                _tx.data,
+                _tx.operation,
+                refundInfo.gasPrice == 0 ? (gasleft() - 2500) : _tx.targetTxGas
+            );
+            // If no targetTxGas and no gasPrice was set (e.g. both are 0), then the internal tx is required to be successful
+            // This makes it possible to use `estimateGas` without issues, as it searches for the minimum gas where the tx doesn't revert
+            if (!success && _tx.targetTxGas == 0 && refundInfo.gasPrice == 0)
+                revert CanNotEstimateGas(
+                    _tx.targetTxGas,
+                    refundInfo.gasPrice,
+                    success
+                );
+            // We transfer the calculated tx costs to the tx.origin to avoid sending it to intermediate contracts that have made calls
+            uint256 payment;
+            if (refundInfo.gasPrice != 0) {
+                payment = handlePaymentV12(
+                    startGas - gasleft(),
+                    refundInfo.baseGas,
+                    refundInfo.gasPrice,
+                    refundInfo.tokenGasPriceFactor,
+                    refundInfo.gasToken,
+                    refundInfo.refundReceiver
+                );
+                emit AccountHandlePayment(txHash, payment);
+            }
+        }
+        {
+            if (guard != address(0)) {
+                Guard(guard).checkAfterExecution(txHash, success);
+            }
+        }
+    }
+
+    /**
+     * @dev Handles the payment for a transaction refund from Smart Account to Relayer.
+     * @param gasUsed Gas used by the transaction.
+     * @param baseGas Gas costs that are independent of the transaction execution
+     * (e.g. base transaction fee, signature check, payment of the refund, emitted events).
+     * @param gasPrice Gas price / TokenGasPrice (gas price in the context of token using offchain price feeds)
+     * that should be used for the payment calculation.
+     * @param tokenGasPriceFactor factor by which calculated token gas price is already multiplied.
+     * @param gasToken Token address (or 0 if ETH) that is used for the payment.
+     * @return payment The amount of payment made in the specified token.
+     */
+    function handlePaymentV12(
+        uint256 gasUsed,
+        uint256 baseGas,
+        uint256 gasPrice,
+        uint256 tokenGasPriceFactor,
+        address gasToken,
+        address payable refundReceiver
+    ) private returns (uint256 payment) {
+        require(tokenGasPriceFactor != 0, "invalid tokenGasPriceFactor");
+        // solhint-disable-next-line avoid-tx-origin
+        address payable receiver = refundReceiver == address(0)
+            ? payable(tx.origin)
+            : refundReceiver;
+        if (gasToken == address(0)) {
+            // For ETH we will only adjust the gas price to not be higher than the actual used gas price
+            payment =
+                (gasUsed + baseGas) *
+                (gasPrice < tx.gasprice ? gasPrice : tx.gasprice);
+            bool success;
+            assembly {
+                success := call(gas(), receiver, payment, 0, 0, 0, 0)
+            }
+            if (!success)
+                revert TokenTransferFailed(address(0), receiver, payment);
+        } else {
+            payment =
+                ((gasUsed + baseGas) * (gasPrice)) /
+                (tokenGasPriceFactor);
+            if (!transferToken(gasToken, receiver, payment))
+                revert TokenTransferFailed(gasToken, receiver, payment);
+        }
+    }
+
+}

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
@@ -7,11 +7,13 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "hardhat/console.sol";
+
 
 contract SmartAccount3 is
     BaseSmartAccount,
@@ -19,6 +21,7 @@ contract SmartAccount3 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
@@ -7,6 +7,7 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount4 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
@@ -7,6 +7,7 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount5 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
@@ -7,6 +7,7 @@ import "./ModuleManagerNew.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount7 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
@@ -7,6 +7,7 @@ import "../../base/ModuleManager.sol";
 import "../../base/FallbackManager.sol";
 import "../../common/SignatureDecoder.sol";
 import "../../common/SecuredTokenTransfer.sol";
+import {ReentrancyGuard} from "../../common/ReentrancyGuard.sol";
 import {SmartAccountErrors} from "../../common/Errors.sol";
 import "../../interfaces/ISignatureValidator.sol";
 import "../../interfaces/IERC165.sol";
@@ -19,6 +20,7 @@ contract SmartAccount9 is
     FallbackManager,
     SignatureDecoder,
     SecuredTokenTransfer,
+    ReentrancyGuard,
     ISignatureValidatorConstants,
     IERC165,
     SmartAccountErrors

--- a/test/proxy-upgrades/enable-guards.ts
+++ b/test/proxy-upgrades/enable-guards.ts
@@ -1,0 +1,394 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import {
+  SmartAccount,
+  SmartAccountFactory,
+  EntryPoint__factory,
+  EntryPoint,
+  MockToken,
+  MultiSend,
+  StorageSetter,
+  DefaultCallbackHandler,
+} from "../../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { encodeTransfer, encodeTransferFrom } from "../smart-wallet/testUtils";
+import {
+  SafeTransaction,
+  Transaction,
+  FeeRefund,
+  safeSignTypedData,
+  buildSafeTransaction,
+  executeContractCallWithSigners,
+} from "../../src/utils/execution";
+import { buildMultiSendSafeTx } from "../../src/utils/multisend";
+import { deployContract } from "../utils/setupHelper";
+
+export async function deployEntryPoint(
+  provider = ethers.provider
+): Promise<EntryPoint> {
+  const epf = await (await ethers.getContractFactory("EntryPoint")).deploy();
+  return EntryPoint__factory.connect(epf.address, provider.getSigner());
+}
+
+describe("Upgrade to enable Guards", function () {
+  // TODO
+  let baseImpl: SmartAccount;
+  let walletFactory: SmartAccountFactory;
+  let entryPoint: EntryPoint;
+  let token: MockToken;
+  let multiSend: MultiSend;
+  let storage: StorageSetter;
+  let owner: string;
+  let bob: string;
+  let charlie: string;
+  let userSCW: any;
+  // let handler: DefaultCallbackHandler;
+  let accounts: any;
+
+  before(async () => {
+    accounts = await ethers.getSigners();
+    owner = await accounts[0].getAddress();
+    bob = await accounts[1].getAddress();
+    charlie = await accounts[2].getAddress();
+
+    const EntryPoint = await ethers.getContractFactory("EntryPoint");
+    entryPoint = await EntryPoint.deploy();
+    await entryPoint.deployed();
+
+    const BaseImplementation = await ethers.getContractFactory("SmartAccount");
+    baseImpl = await BaseImplementation.deploy(entryPoint.address);
+    await baseImpl.deployed();
+
+    const WalletFactory = await ethers.getContractFactory(
+      "SmartAccountFactory"
+    );
+    walletFactory = await WalletFactory.deploy(baseImpl.address);
+    await walletFactory.deployed();
+
+    const MockToken = await ethers.getContractFactory("MockToken");
+    token = await MockToken.deploy();
+    await token.deployed();
+
+    const Storage = await ethers.getContractFactory("StorageSetter");
+    storage = await Storage.deploy();
+
+    const MultiSend = await ethers.getContractFactory("MultiSend");
+    multiSend = await MultiSend.deploy();
+
+    await token.mint(owner, ethers.utils.parseEther("1000000"));
+  });
+
+  it("Should deploy a wallet and validate entrypoint", async function () {
+    const expected = await walletFactory.getAddressForCounterfactualAccount(
+      owner,
+      0
+    );
+    console.log("deploying new wallet..expected address: ", expected);
+
+    await expect(walletFactory.deployCounterFactualAccount(owner, 0))
+      .to.emit(walletFactory, "AccountCreation")
+      .withArgs(expected, owner, 0);
+
+    userSCW = await ethers.getContractAt(
+      "contracts/smart-contract-wallet/SmartAccount.sol:SmartAccount",
+      expected
+    );
+
+    const entryPointAddress = await userSCW.entryPoint();
+    expect(entryPointAddress).to.equal(entryPoint.address);
+
+    await accounts[1].sendTransaction({
+      from: bob,
+      to: expected,
+      value: ethers.utils.parseEther("5"),
+    });
+  });
+
+  it("Should deploy new implementation and upgrade", async function () {
+
+    const BaseImplementation2 = await ethers.getContractFactory(
+      "SmartAccount12Guard"
+    );
+    const baseImpl12 = await BaseImplementation2.deploy(entryPoint.address);
+    await baseImpl12.deployed();
+    console.log("Upgraded Smart Account deployed at: ", baseImpl12.address);
+
+    await expect(
+      userSCW.connect(accounts[0]).updateImplementation(baseImpl12.address)
+    ).to.emit(userSCW, "ImplementationUpdated");
+
+    userSCW = await ethers.getContractAt(
+      "contracts/smart-contract-wallet/test/upgrades/SmartAccount12Guard.sol:SmartAccount12Guard",
+      userSCW.address
+    );
+    
+  });
+
+  it("should send a single transacton (EIP712 sign) with upgraded implementation", async function () {
+    await token
+      .connect(accounts[0])
+      .transfer(userSCW.address, ethers.utils.parseEther("100"));
+
+    const amountToTransfer = ethers.utils.parseEther("10");
+    const balanceCharlieBefore = await token.balanceOf(charlie);
+      
+    const safeTx: SafeTransaction = buildSafeTransaction({
+      to: token.address,
+      // value: ethers.utils.parseEther("1"),
+      data: encodeTransfer(charlie, amountToTransfer.toString()),
+      nonce: await userSCW.getNonce(1),
+    });
+
+    const chainId = await userSCW.getChainId();
+    const { signer, data } = await safeSignTypedData(
+      accounts[0],
+      userSCW,
+      safeTx,
+      chainId
+    );
+
+    const transaction: Transaction = {
+      to: safeTx.to,
+      value: safeTx.value,
+      data: safeTx.data,
+      operation: safeTx.operation,
+      targetTxGas: safeTx.targetTxGas,
+    };
+    const refundInfo: FeeRefund = {
+      baseGas: safeTx.baseGas,
+      gasPrice: safeTx.gasPrice,
+      tokenGasPriceFactor: safeTx.tokenGasPriceFactor,
+      gasToken: safeTx.gasToken,
+      refundReceiver: safeTx.refundReceiver,
+    };
+
+    let signature = "0x";
+    signature += data.slice(2);
+    await expect(
+      userSCW
+        .connect(accounts[0])
+        .execTransaction_S6W(transaction, refundInfo, signature)
+    ).to.emit(userSCW, "ExecutionSuccess");
+
+    expect(await token.balanceOf(charlie)).to.equal(
+      balanceCharlieBefore.add(amountToTransfer)
+    );
+  });
+
+  it("should deploy and connect the guard", async function () {
+
+    const IncrNonceLib = await ethers.getContractFactory("TestIncreaseNonceLib");
+    const trustedTarget = await IncrNonceLib.deploy();
+    await trustedTarget.deployed();
+
+    const DelegateCallGuard = await ethers.getContractFactory(
+      "DelegateCallTransactionGuard"
+    );
+    const dcGuard = await DelegateCallGuard.deploy(trustedTarget.address);
+    await dcGuard.deployed();
+    console.log("Delegate Call Guard deployed to: ", dcGuard.address);
+
+    await expect(
+      executeContractCallWithSigners(
+        userSCW,
+        userSCW,
+        "setGuard",
+        [dcGuard.address],
+        [accounts[0]]
+      )
+    ).to.emit(userSCW, "ExecutionSuccess");
+
+    expect(await userSCW.getGuard()).to.equal(dcGuard.address);dcGuard.address
+
+  });
+
+  it("should still allow calls (not delegatecalls) thru the guard", async function () {
+
+    const IncrNonceLib = await ethers.getContractFactory("TestIncreaseNonceLib");
+    const trustedTarget = await IncrNonceLib.deploy();
+    await trustedTarget.deployed();
+
+    const DelegateCallGuard = await ethers.getContractFactory(
+      "DelegateCallTransactionGuard"
+    );
+    const dcGuard = await DelegateCallGuard.deploy(trustedTarget.address);
+    await dcGuard.deployed();
+
+    await executeContractCallWithSigners(userSCW,userSCW,"setGuard",[dcGuard.address],[accounts[0]]);
+    
+    await token
+      .connect(accounts[0])
+      .transfer(userSCW.address, ethers.utils.parseEther("100"));
+
+    const amountToTransfer = ethers.utils.parseEther("10");
+    const balanceCharlieBefore = await token.balanceOf(charlie);
+
+    const safeTx: SafeTransaction = buildSafeTransaction({
+      to: token.address,
+      // value: ethers.utils.parseEther("1"),
+      data: encodeTransfer(charlie, amountToTransfer.toString()),
+      nonce: await userSCW.getNonce(1),
+    });
+
+    const chainId = await userSCW.getChainId();
+    const { signer, data } = await safeSignTypedData(
+      accounts[0],
+      userSCW,
+      safeTx,
+      chainId
+    );
+
+    const transaction: Transaction = {
+      to: safeTx.to,
+      value: safeTx.value,
+      data: safeTx.data,
+      operation: safeTx.operation,
+      targetTxGas: safeTx.targetTxGas,
+    };
+    const refundInfo: FeeRefund = {
+      baseGas: safeTx.baseGas,
+      gasPrice: safeTx.gasPrice,
+      tokenGasPriceFactor: safeTx.tokenGasPriceFactor,
+      gasToken: safeTx.gasToken,
+      refundReceiver: safeTx.refundReceiver,
+    };
+
+    let signature = "0x";
+    signature += data.slice(2);
+    await expect(
+      userSCW
+        .connect(accounts[0])
+        .execTransaction_S6W(transaction, refundInfo, signature)
+    ).to.emit(userSCW, "ExecutionSuccess");
+
+    expect(await token.balanceOf(charlie)).to.equal(
+      balanceCharlieBefore.add(amountToTransfer)
+    );
+
+  });
+
+  it("Should revert for delegatecall to unapproved contract", async function () {
+
+    const IncrNonceLib = await ethers.getContractFactory("TestIncreaseNonceLib");
+    const trustedTarget = await IncrNonceLib.deploy();
+    await trustedTarget.deployed();
+
+    const nonTrustedTarget = await IncrNonceLib.deploy();
+    await nonTrustedTarget.deployed();
+
+    const DelegateCallGuard = await ethers.getContractFactory(
+      "DelegateCallTransactionGuard"
+    );
+    const dcGuard = await DelegateCallGuard.deploy(trustedTarget.address);
+    await dcGuard.deployed();
+
+    await executeContractCallWithSigners(userSCW, userSCW, "setGuard",[dcGuard.address], [accounts[0]]);
+
+    const delegateCall = 1;
+
+    const safeTx: SafeTransaction = buildSafeTransaction({
+      to: nonTrustedTarget.address,
+      operation: delegateCall,
+      data: nonTrustedTarget.interface.encodeFunctionData("increaseNonce", [2]),
+      nonce: await userSCW.getNonce(1),
+    });
+
+    const chainId = await userSCW.getChainId();
+    const { signer, data } = await safeSignTypedData(
+      accounts[0],
+      userSCW,
+      safeTx,
+      chainId
+    );
+
+    const transaction: Transaction = {
+      to: safeTx.to,
+      value: safeTx.value,
+      data: safeTx.data,
+      operation: safeTx.operation,
+      targetTxGas: safeTx.targetTxGas,
+    };
+    const refundInfo: FeeRefund = {
+      baseGas: safeTx.baseGas,
+      gasPrice: safeTx.gasPrice,
+      tokenGasPriceFactor: safeTx.tokenGasPriceFactor,
+      gasToken: safeTx.gasToken,
+      refundReceiver: safeTx.refundReceiver,
+    };
+
+    let signature = "0x";
+    signature += data.slice(2);
+
+    await expect(
+      userSCW
+        .connect(accounts[0])
+        .execTransaction_S6W(transaction, refundInfo, signature)
+    ).to.be.revertedWith("DelegateCallGuardRestricted");
+
+  });
+
+  it("Should allow delegatecall to approved contract", async function () {
+
+    const IncrNonceLib = await ethers.getContractFactory("TestIncreaseNonceLib");
+    const trustedTarget = await IncrNonceLib.deploy();
+    await trustedTarget.deployed();
+
+    const nonTrustedTarget = await IncrNonceLib.deploy();
+    await nonTrustedTarget.deployed();
+
+    const DelegateCallGuard = await ethers.getContractFactory(
+      "DelegateCallTransactionGuard"
+    );
+    const dcGuard = await DelegateCallGuard.deploy(trustedTarget.address);
+    await dcGuard.deployed();
+
+    await executeContractCallWithSigners(userSCW, userSCW, "setGuard",[dcGuard.address], [accounts[0]]);
+
+    const delegateCall = 1;
+    const testBatchId = 2;
+    const nonceBefore = await userSCW.nonces(testBatchId);
+
+    const safeTx: SafeTransaction = buildSafeTransaction({
+      to: trustedTarget.address,
+      operation: delegateCall,
+      data: nonTrustedTarget.interface.encodeFunctionData("increaseNonce", [testBatchId]),
+      nonce: await userSCW.getNonce(1),
+    });
+
+    const chainId = await userSCW.getChainId();
+    const { signer, data } = await safeSignTypedData(
+      accounts[0],
+      userSCW,
+      safeTx,
+      chainId
+    );
+
+    const transaction: Transaction = {
+      to: safeTx.to,
+      value: safeTx.value,
+      data: safeTx.data,
+      operation: safeTx.operation,
+      targetTxGas: safeTx.targetTxGas,
+    };
+    const refundInfo: FeeRefund = {
+      baseGas: safeTx.baseGas,
+      gasPrice: safeTx.gasPrice,
+      tokenGasPriceFactor: safeTx.tokenGasPriceFactor,
+      gasToken: safeTx.gasToken,
+      refundReceiver: safeTx.refundReceiver,
+    };
+
+    let signature = "0x";
+    signature += data.slice(2);
+
+    await
+      userSCW
+        .connect(accounts[0])
+        .execTransaction_S6W(transaction, refundInfo, signature);
+
+    expect(await userSCW.nonces(testBatchId)).to.equal(nonceBefore.add(1));
+
+  });
+
+  
+});


### PR DESCRIPTION
* Added custom Reentrancy Guard implementation (strongly inspired by OZ's)
* Added guard to execTransaction only as handlePayment is private and called from execTransaction, transfer and pullTokens are onlyOwner thus don't think they need to be protected
* Added tedt GuardManager implementation and one Guard (DelegateCallGuard)
* Added Smart Account with Guard Manager implementation and test cases to upgrade to this implementation, enable guard and check it's functionality.