### PR TITLE
rename signMessage=>signMessageOnchain

### DIFF
--- a/contracts/smart-contract-wallet/libs/SignMessageLib.sol
+++ b/contracts/smart-contract-wallet/libs/SignMessageLib.sol
@@ -23,7 +23,7 @@ contract SignMessageLib is SmartAccountStorage {
     /// @dev Marks a message as signed, so that it can be used with EIP-1271
     /// @notice Marks a message (`_data`) as signed.
     /// @param _data Arbitrary length data that should be marked as signed on the behalf of address(this) smart account
-    function signMessage(bytes calldata _data) external {
+    function signMessageOnchain(bytes calldata _data) external {
         bytes32 msgHash = getMessageHash(_data);
         signedMessages[msgHash] = 1;
         emit MessageSigned(msgHash);

--- a/test/smart-wallet/signatures/EIP1271Test.ts
+++ b/test/smart-wallet/signatures/EIP1271Test.ts
@@ -354,7 +354,7 @@ describe("EIP-1271 Signatures Tests", function () {
     const message = "Some message from dApp";
     const signature = await accounts[0].signMessage(message);
 
-    // since signMessage actually signs the message hash prepended by
+    // since .signMessage actually signs the message hash prepended by
     // \x19Ethereum Signed Message:\n" and the length of the message
     // we use .hashMessage to get message hash to verify against
     const messageHash = ethers.utils.hashMessage(message);

--- a/test/smart-wallet/testUtils.ts
+++ b/test/smart-wallet/testUtils.ts
@@ -136,7 +136,7 @@ export const Erc20 = [
 export const Erc20Interface = new ethers.utils.Interface(Erc20);
 
 export const SignMessageLib = [
-  "function signMessage(bytes calldata _data) external",
+  "function signMessageOnchain(bytes calldata _data) external",
 ];
 
 export const SignMessageLibInterface = new ethers.utils.Interface(
@@ -163,5 +163,5 @@ export const encodeTransferFrom = (
 };
 
 export const encodeSignMessage = (data: string): string => {
-  return SignMessageLibInterface.encodeFunctionData("signMessage", [data]);
+  return SignMessageLibInterface.encodeFunctionData("signMessageOnchain", [data]);
 };


### PR DESCRIPTION
Renamed signMessage=>signMessageOnchain in the MesageLib to avoid confusion with the `signMessage` offchain method of the signer instance