### PR TITLE
make _validateAndUpdateNonce and getNonce virtual

### DIFF
--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -214,7 +214,7 @@ contract SmartAccount is
      * @param batchId : the key of the user's batch being queried
      * @return nonce : the number of transactions made within said batch
      */
-    function getNonce(uint256 batchId) public view returns (uint256) {
+    function getNonce(uint256 batchId) public view virtual returns (uint256) {
         return nonces[batchId];
     }
 
@@ -741,7 +741,7 @@ contract SmartAccount is
      */
     function _validateAndUpdateNonce(
         UserOperation calldata userOp
-    ) internal override {
+    ) internal virtual override {
         if (nonces[0]++ != userOp.nonce)
             revert InvalidUserOpNonceProvided(userOp.nonce, nonces[0]);
     }


### PR DESCRIPTION
I have currently made above methods virtual. nonce() is already virtual

Context:

https://docs.google.com/document/d/1MywdH_TCkyEjD3QusLZ_kUZg4ZEI00qp97mBze9JI4k/edit#

https://github.com/eth-infinitism/account-abstraction/pull/247/files


**Implication for Accounts**

- The account no longer needs to maintain its own nonce (though it will not do any harm if it continues to - except for wasting gas)

- An account can enforce sequential nonces, by doing

```
require(userOp.nonce<type(uint64).max)
(that is, prevent using a “key” different from the first “zero” key)
```

- For the next plain sequential nonce, the account’s getNonce() should be implemented as `entryPoint.getNonce(this, 0)`


"This functionality is maintained by calling entryPoint.getNonce(account) from the account’s nonce function."
IMO we can still keep original nonces state for direct, non-ERC4337 calls and use getNonce() method for it. For userOp nonce we currently use nonce() method

However, whole change needs to be evaluated for below questions...

_are you planning to use any custom replay protection scheme?
Do you think your planned replay protection can’t be supported by this change?_
 
