### PR TITLE
update contracts rebased with 0.6.0

### DIFF
--- a/contracts/smart-contract-wallet/BaseSmartAccount.sol
+++ b/contracts/smart-contract-wallet/BaseSmartAccount.sol
@@ -42,9 +42,12 @@ abstract contract BaseSmartAccount is IAccount, BaseSmartAccountErrors {
 
     /**
      * @return nonce the account nonce.
-     * subclass should return a nonce value that is used both by _validateAndUpdateNonce, and by the external provider (to read the current nonce)
+     * @dev This method returns the next sequential nonce.
+     * @notice For a nonce of a specific key, use `entrypoint.getNonce(account, key)`
      */
-    function nonce() public view virtual returns (uint256);
+    function nonce() public view virtual returns (uint256) {
+        return entryPoint().getNonce(address(this), 0);
+    }
 
     /**
      * return the entryPoint used by this account.
@@ -65,9 +68,7 @@ abstract contract BaseSmartAccount is IAccount, BaseSmartAccountErrors {
         if (msg.sender != address(entryPoint()))
             revert CallerIsNotAnEntryPoint(msg.sender);
         validationData = _validateSignature(userOp, userOpHash);
-        if (userOp.initCode.length == 0) {
-            _validateAndUpdateNonce(userOp);
-        }
+        _validateNonce(userOp.nonce);
         _payPrefund(missingAccountFunds);
     }
 
@@ -90,14 +91,22 @@ abstract contract BaseSmartAccount is IAccount, BaseSmartAccountErrors {
     ) internal virtual returns (uint256 validationData);
 
     /**
-     * validate the current nonce matches the UserOperation nonce.
-     * then it should update the account's state to prevent replay of this UserOperation.
-     * called only if initCode is empty (since "nonce" field is used as "salt" on account creation)
-     * @param userOp the op to validate.
+     * Validate the nonce of the UserOperation.
+     * This method may validate the nonce requirement of this account.
+     * e.g.
+     * To limit the nonce to use sequenced UserOps only (no "out of order" UserOps):
+     *      `require(nonce < type(uint64).max)`
+     * For a hypothetical account that *requires* the nonce to be out-of-order:
+     *      `require(nonce & type(uint64).max == 0)`
+     *
+     * The actual nonce uniqueness is managed by the EntryPoint, and thus no other
+     * action is needed by the account itself.
+     *
+     * @param nonce to validate
+     *
+     * solhint-disable-next-line no-empty-blocks
      */
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal virtual;
+    function _validateNonce(uint256 nonce) internal view virtual {}
 
     /**
      * sends to the entrypoint (msg.sender) the missing funds for this transaction.

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -731,17 +731,6 @@ contract SmartAccount is
     }
 
     /**
-     * @dev implement template method of BaseAccount
-     * @notice Nonce space is locked to 0 for AA transactions
-     */
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal virtual override {
-        if (nonces[0]++ != userOp.nonce)
-            revert InvalidUserOpNonceProvided(userOp.nonce, nonces[0]);
-    }
-
-    /**
      * @dev Implements the template method of BaseAccount and validates the user's signature for a given operation.
      * @notice This function is marked as internal and virtual, and it overrides the BaseAccount function of the same name.
      * @param userOp The user operation to be validated, provided as a `UserOperation` calldata struct.

--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -215,13 +215,6 @@ contract SmartAccount is
     }
 
     /**
-     * @dev Standard interface for 1d nonces. Use it for Account Abstraction flow.
-     */
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
-    /**
      * @dev Returns the current entry point used by this account.
      * @return EntryPoint as an `IEntryPoint` interface.
      * @dev This function should be implemented by the subclass to return the current entry point used by this account.

--- a/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
+++ b/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
@@ -529,15 +529,6 @@ contract SmartAccountNoAuth is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
+++ b/contracts/smart-contract-wallet/SmartAccountNoAuth.sol
@@ -101,10 +101,6 @@ contract SmartAccountNoAuth is
         _;
     }
 
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/aa-4337/core/BaseAccount.sol
+++ b/contracts/smart-contract-wallet/aa-4337/core/BaseAccount.sol
@@ -2,8 +2,7 @@
 pragma solidity 0.8.17;
 
 /* solhint-disable avoid-low-level-calls */
-/* solhint-disable no-inline-assembly */
-/* solhint-disable reason-string */
+/* solhint-disable no-empty-blocks */
 
 import {IAccount} from "../interfaces/IAccount.sol";
 import {IEntryPoint} from "../interfaces/IEntryPoint.sol";
@@ -23,10 +22,13 @@ abstract contract BaseAccount is IAccount {
     uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
     /**
-     * return the account nonce.
-     * subclass should return a nonce value that is used both by _validateAndUpdateNonce, and by the external provider (to read the current nonce)
+     * Return the account nonce.
+     * This method returns the next sequential nonce.
+     * For a nonce of a specific key, use `entrypoint.getNonce(account, key)`
      */
-    function nonce() public view virtual returns (uint256);
+    function getNonce() public view virtual returns (uint256) {
+        return entryPoint().getNonce(address(this), 0);
+    }
 
     /**
      * return the entryPoint used by this account.
@@ -45,9 +47,7 @@ abstract contract BaseAccount is IAccount {
     ) external virtual override returns (uint256 validationData) {
         _requireFromEntryPoint();
         validationData = _validateSignature(userOp, userOpHash);
-        if (userOp.initCode.length == 0) {
-            _validateAndUpdateNonce(userOp);
-        }
+        _validateNonce(userOp.nonce);
         _payPrefund(missingAccountFunds);
     }
 
@@ -80,14 +80,22 @@ abstract contract BaseAccount is IAccount {
     ) internal virtual returns (uint256 validationData);
 
     /**
-     * validate the current nonce matches the UserOperation nonce.
-     * then it should update the account's state to prevent replay of this UserOperation.
-     * called only if initCode is empty (since "nonce" field is used as "salt" on account creation)
-     * @param userOp the op to validate.
+     * Validate the nonce of the UserOperation.
+     * This method may validate the nonce requirement of this account.
+     * e.g.
+     * To limit the nonce to use sequenced UserOps only (no "out of order" UserOps):
+     *      `require(nonce < type(uint64).max)`
+     * For a hypothetical account that *requires* the nonce to be out-of-order:
+     *      `require(nonce & type(uint64).max == 0)`
+     *
+     * The actual nonce uniqueness is managed by the EntryPoint, and thus no other
+     * action is needed by the account itself.
+     *
+     * @param nonce to validate
+     *
+     * solhint-disable-next-line no-empty-blocks
      */
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal virtual;
+    function _validateNonce(uint256 nonce) internal view virtual {}
 
     /**
      * sends to the entrypoint (msg.sender) the missing funds for this transaction.

--- a/contracts/smart-contract-wallet/aa-4337/core/EntryPoint.sol
+++ b/contracts/smart-contract-wallet/aa-4337/core/EntryPoint.sol
@@ -16,8 +16,15 @@ import "../utils/Exec.sol";
 import "./StakeManager.sol";
 import "./SenderCreator.sol";
 import "./Helpers.sol";
+import "./NonceManager.sol";
+import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
-contract EntryPoint is IEntryPoint, StakeManager {
+contract EntryPoint is
+    IEntryPoint,
+    StakeManager,
+    NonceManager,
+    ReentrancyGuard
+{
     using UserOperationLib for UserOperation;
 
     SenderCreator private immutable senderCreator = new SenderCreator();
@@ -101,7 +108,7 @@ contract EntryPoint is IEntryPoint, StakeManager {
     function handleOps(
         UserOperation[] calldata ops,
         address payable beneficiary
-    ) public {
+    ) public nonReentrant {
         uint256 opslen = ops.length;
         UserOpInfo[] memory opInfos = new UserOpInfo[](opslen);
 
@@ -121,6 +128,7 @@ contract EntryPoint is IEntryPoint, StakeManager {
             }
 
             uint256 collected = 0;
+            emit BeforeExecution();
 
             for (uint256 i = 0; i < opslen; i++) {
                 collected += _executeUserOp(i, ops[i], opInfos[i]);
@@ -138,7 +146,7 @@ contract EntryPoint is IEntryPoint, StakeManager {
     function handleAggregatedOps(
         UserOpsPerAggregator[] calldata opsPerAggregator,
         address payable beneficiary
-    ) public {
+    ) public nonReentrant {
         uint256 opasLen = opsPerAggregator.length;
         uint256 totalOps = 0;
         for (uint256 i = 0; i < opasLen; i++) {
@@ -163,6 +171,8 @@ contract EntryPoint is IEntryPoint, StakeManager {
         }
 
         UserOpInfo[] memory opInfos = new UserOpInfo[](totalOps);
+
+        emit BeforeExecution();
 
         uint256 opIndex = 0;
         for (uint256 a = 0; a < opasLen; a++) {
@@ -463,7 +473,8 @@ contract EntryPoint is IEntryPoint, StakeManager {
      * @param initCode the constructor code to be passed into the UserOperation.
      */
     function getSenderAddress(bytes calldata initCode) public {
-        revert SenderAddressResult(senderCreator.createSender(initCode));
+        address sender = senderCreator.createSender(initCode);
+        revert SenderAddressResult(sender);
     }
 
     function _simulationOnlyValidations(
@@ -701,6 +712,11 @@ contract EntryPoint is IEntryPoint, StakeManager {
             outOpInfo,
             requiredPreFund
         );
+
+        if (!_validateAndUpdateNonce(mUserOp.sender, mUserOp.nonce)) {
+            revert FailedOp(opIndex, "AA25 invalid account nonce");
+        }
+
         //a "marker" where account opcode validation is done and paymaster opcode validation is about to start
         // (used only by off-chain simulateValidation)
         numberMarker();

--- a/contracts/smart-contract-wallet/aa-4337/core/Helpers.sol
+++ b/contracts/smart-contract-wallet/aa-4337/core/Helpers.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
+/* solhint-disable no-inline-assembly */
+
 /**
  * returned data from validateUserOp.
  * validateUserOp returns a uint256, with is created by `_packedValidationData` and parsed by `_parseValidationData`
@@ -83,4 +85,17 @@ function _packValidationData(
         (sigFailed ? 1 : 0) |
         (uint256(validUntil) << 160) |
         (uint256(validAfter) << (160 + 48));
+}
+
+/**
+ * keccak function over calldata.
+ * @dev copy calldata into memory, do keccak and drop allocated memory. Strangely, this is more efficient than letting solidity do it.
+ */
+function calldataKeccak(bytes calldata data) pure returns (bytes32 ret) {
+    assembly {
+        let mem := mload(0x40)
+        let len := data.length
+        calldatacopy(mem, data.offset, len)
+        ret := keccak256(mem, len)
+    }
 }

--- a/contracts/smart-contract-wallet/aa-4337/core/NonceManager.sol
+++ b/contracts/smart-contract-wallet/aa-4337/core/NonceManager.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+import {IEntryPoint} from "../interfaces/IEntryPoint.sol";
+import {INonceManager} from "../interfaces/INonceManager.sol";
+
+/**
+ * nonce management functionality
+ */
+contract NonceManager is INonceManager {
+    /**
+     * The next valid sequence number for a given nonce key.
+     */
+    mapping(address => mapping(uint192 => uint256)) public nonceSequenceNumber;
+
+    function getNonce(
+        address sender,
+        uint192 key
+    ) public view override returns (uint256 nonce) {
+        return nonceSequenceNumber[sender][key] | (uint256(key) << 64);
+    }
+
+    // allow an account to manually increment its own nonce.
+    // (mainly so that during construction nonce can be made non-zero,
+    // to "absorb" the gas cost of first nonce increment to 1st transaction (construction),
+    // not to 2nd transaction)
+    function incrementNonce(uint192 key) public override {
+        nonceSequenceNumber[msg.sender][key]++;
+    }
+
+    /**
+     * validate nonce uniqueness for this account.
+     * called just after validateUserOp()
+     */
+    function _validateAndUpdateNonce(
+        address sender,
+        uint256 nonce
+    ) internal returns (bool) {
+        uint192 key = uint192(nonce >> 64);
+        uint64 seq = uint64(nonce);
+        return nonceSequenceNumber[sender][key]++ == seq;
+    }
+}

--- a/contracts/smart-contract-wallet/aa-4337/interfaces/IEntryPoint.sol
+++ b/contracts/smart-contract-wallet/aa-4337/interfaces/IEntryPoint.sol
@@ -12,8 +12,9 @@ pragma solidity 0.8.17;
 import "./UserOperation.sol";
 import "./IStakeManager.sol";
 import "./IAggregator.sol";
+import "./INonceManager.sol";
 
-interface IEntryPoint is IStakeManager {
+interface IEntryPoint is IStakeManager, INonceManager {
     /***
      * An event emitted after each successful request
      * @param userOpHash - unique identifier for the request (hash its entire content, except signature).
@@ -61,6 +62,12 @@ interface IEntryPoint is IStakeManager {
         uint256 nonce,
         bytes revertReason
     );
+
+    /**
+     * an event emitted by handleOps(), before starting the execution loop.
+     * any event emitted before this event, is part of the validation.
+     */
+    event BeforeExecution();
 
     /**
      * signature aggregator used by the following UserOperationEvents within this bundle.

--- a/contracts/smart-contract-wallet/aa-4337/interfaces/INonceManager.sol
+++ b/contracts/smart-contract-wallet/aa-4337/interfaces/INonceManager.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+interface INonceManager {
+    /**
+     * Return the next nonce for this sender.
+     * Within a given key, the nonce values are sequenced (starting with zero, and incremented by one on each userop)
+     * But UserOp with different keys can come with arbitrary order.
+     *
+     * @param sender the account address
+     * @param key the high 192 bit of the nonce
+     * @return nonce a full nonce to pass for next UserOp with this sender.
+     */
+    function getNonce(
+        address sender,
+        uint192 key
+    ) external view returns (uint256 nonce);
+
+    /**
+     * Manually increment the nonce of the sender.
+     * This method is exposed just for completeness..
+     * Account does NOT need to call it, neither during validation, nor elsewhere,
+     * as the EntryPoint will update the nonce regardless.
+     * Possible use-case is call it with various keys to "initialize" their nonces to one, so that future
+     * UserOperations will not pay extra for the first transaction with a given key.
+     */
+    function incrementNonce(uint192 key) external;
+}

--- a/contracts/smart-contract-wallet/aa-4337/interfaces/UserOperation.sol
+++ b/contracts/smart-contract-wallet/aa-4337/interfaces/UserOperation.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.17;
 
 /* solhint-disable no-inline-assembly */
 
+import {calldataKeccak} from "../core/Helpers.sol";
+
 /**
  * User Operation struct
  * @param sender the sender account of this request.
@@ -65,19 +67,30 @@ library UserOperationLib {
     function pack(
         UserOperation calldata userOp
     ) internal pure returns (bytes memory ret) {
-        //lighter signature scheme. must match UserOp.ts#packUserOp
-        bytes calldata sig = userOp.signature;
-        // copy directly the userOp from calldata up to (but not including) the signature.
-        // this encoding depends on the ABI encoding of calldata, but is much lighter to copy
-        // than referencing each field separately.
-        assembly {
-            let ofs := userOp
-            let len := sub(sub(sig.offset, ofs), 32)
-            ret := mload(0x40)
-            mstore(0x40, add(ret, add(len, 32)))
-            mstore(ret, len)
-            calldatacopy(add(ret, 32), ofs, len)
-        }
+        address sender = getSender(userOp);
+        uint256 nonce = userOp.nonce;
+        bytes32 hashInitCode = calldataKeccak(userOp.initCode);
+        bytes32 hashCallData = calldataKeccak(userOp.callData);
+        uint256 callGasLimit = userOp.callGasLimit;
+        uint256 verificationGasLimit = userOp.verificationGasLimit;
+        uint256 preVerificationGas = userOp.preVerificationGas;
+        uint256 maxFeePerGas = userOp.maxFeePerGas;
+        uint256 maxPriorityFeePerGas = userOp.maxPriorityFeePerGas;
+        bytes32 hashPaymasterAndData = calldataKeccak(userOp.paymasterAndData);
+
+        return
+            abi.encode(
+                sender,
+                nonce,
+                hashInitCode,
+                hashCallData,
+                callGasLimit,
+                verificationGasLimit,
+                preVerificationGas,
+                maxFeePerGas,
+                maxPriorityFeePerGas,
+                hashPaymasterAndData
+            );
     }
 
     function hash(

--- a/contracts/smart-contract-wallet/aa-4337/samples/callback/TokenCallbackHandler.sol
+++ b/contracts/smart-contract-wallet/aa-4337/samples/callback/TokenCallbackHandler.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.17;
+
+/* solhint-disable no-empty-blocks */
+
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import "@openzeppelin/contracts/token/ERC777/IERC777Recipient.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+
+/**
+ * Token callback handler.
+ *   Handles supported tokens' callbacks, allowing account receiving these tokens.
+ */
+contract TokenCallbackHandler is
+    IERC777Recipient,
+    IERC721Receiver,
+    IERC1155Receiver
+{
+    function tokensReceived(
+        address,
+        address,
+        address,
+        uint256,
+        bytes calldata,
+        bytes calldata
+    ) external pure override {}
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC1155Receiver.onERC1155Received.selector;
+    }
+
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) external view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC721Receiver).interfaceId ||
+            interfaceId == type(IERC1155Receiver).interfaceId ||
+            interfaceId == type(IERC165).interfaceId;
+    }
+}

--- a/contracts/smart-contract-wallet/aa-4337/test/MaliciousAccount.sol
+++ b/contracts/smart-contract-wallet/aa-4337/test/MaliciousAccount.sol
@@ -17,13 +17,14 @@ contract MaliciousAccount is IAccount {
         uint256 missingAccountFunds
     ) external returns (uint256 validationData) {
         ep.depositTo{value: missingAccountFunds}(address(this));
-        // Now calculate basefee per EntryPoint.getUserOpGasPrice() and compare it to the basefe we pass off-chain as nonce
+        // Now calculate basefee per EntryPoint.getUserOpGasPrice() and compare it to the basefe we pass off-chain in the signature
+        uint256 externalBaseFee = abi.decode(userOp.signature, (uint256));
         uint256 requiredGas = userOp.callGasLimit +
             userOp.verificationGasLimit +
             userOp.preVerificationGas;
         uint256 gasPrice = missingAccountFunds / requiredGas;
         uint256 basefee = gasPrice - userOp.maxPriorityFeePerGas;
-        require(basefee == userOp.nonce, "Revert after first validation");
+        require(basefee == externalBaseFee, "Revert after first validation");
         return 0;
     }
 }

--- a/contracts/smart-contract-wallet/test/MaliciousAccount2.sol
+++ b/contracts/smart-contract-wallet/test/MaliciousAccount2.sol
@@ -544,19 +544,6 @@ contract MaliciousAccount2 is
     }
 
     /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        // No nonce to REUSE THE GAS PAYMENT
-        //require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-        // bytes calldata userOpData = userOp.callData;
-        // (address _to, uint256 _amount, bytes memory _data) = abi.decode(userOpData[4:], (address, uint256, bytes));
-        // if(address(modules[_to]) != address(0)) return;
-    }
-
-    /// implement template method of BaseAccount
     function _validateSignature(
         UserOperation calldata userOp,
         bytes32 userOpHash

--- a/contracts/smart-contract-wallet/test/MaliciousAccount2.sol
+++ b/contracts/smart-contract-wallet/test/MaliciousAccount2.sol
@@ -100,10 +100,6 @@ contract MaliciousAccount2 is
         _;
     }
 
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/BaseSmartAccountNew.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/BaseSmartAccountNew.sol
@@ -41,10 +41,13 @@ abstract contract BaseSmartAccountNew is IAccount, BaseSmartAccountErrors {
     uint256 internal constant SIG_VALIDATION_FAILED = 1;
 
     /**
-     * return the account nonce.
-     * subclass should return a nonce value that is used both by _validateAndUpdateNonce, and by the external provider (to read the current nonce)
+     * @return nonce the account nonce.
+     * @dev This method returns the next sequential nonce.
+     * @notice For a nonce of a specific key, use `entrypoint.getNonce(account, key)`
      */
-    function nonce() public view virtual returns (uint256);
+    function nonce() public view virtual returns (uint256) {
+        return entryPoint().getNonce(address(this), 0);
+    }
 
     /**
      * return the entryPoint used by this account.
@@ -64,9 +67,7 @@ abstract contract BaseSmartAccountNew is IAccount, BaseSmartAccountErrors {
         if (msg.sender != address(entryPoint()))
             revert CallerIsNotAnEntryPoint(msg.sender);
         validationData = _validateSignature(userOp, userOpHash);
-        if (userOp.initCode.length == 0) {
-            _validateAndUpdateNonce(userOp);
-        }
+        _validateNonce(userOp.nonce);
         _payPrefund(missingAccountFunds);
     }
 
@@ -99,14 +100,22 @@ abstract contract BaseSmartAccountNew is IAccount, BaseSmartAccountErrors {
     ) internal virtual returns (uint256 validationData);
 
     /**
-     * validate the current nonce matches the UserOperation nonce.
-     * then it should update the account's state to prevent replay of this UserOperation.
-     * called only if initCode is empty (since "nonce" field is used as "salt" on account creation)
-     * @param userOp the op to validate.
+     * Validate the nonce of the UserOperation.
+     * This method may validate the nonce requirement of this account.
+     * e.g.
+     * To limit the nonce to use sequenced UserOps only (no "out of order" UserOps):
+     *      `require(nonce < type(uint64).max)`
+     * For a hypothetical account that *requires* the nonce to be out-of-order:
+     *      `require(nonce & type(uint64).max == 0)`
+     *
+     * The actual nonce uniqueness is managed by the EntryPoint, and thus no other
+     * action is needed by the account itself.
+     *
+     * @param nonce to validate
+     *
+     * solhint-disable-next-line no-empty-blocks
      */
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal virtual;
+    function _validateNonce(uint256 nonce) internal view virtual {}
 
     /**
      * sends to the entrypoint (msg.sender) the missing funds for this transaction.

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
@@ -168,11 +168,6 @@ contract SmartAccount10 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount10.sol
@@ -564,15 +564,6 @@ contract SmartAccount10 is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
@@ -684,21 +684,6 @@ contract SmartAccount11 is
 
     /**
      * @dev implement template method of BaseAccount
-     * @notice Nonce space is locked to 0 for AA transactions
-     */
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        if (nonces[0]++ != userOp.nonce)
-            revert InvalidUserOpNonceProvided(userOp.nonce, nonces[0]);
-
-        // Compatiblity options, should choose one
-        //if(nonces[0]++ != userOp.nonce) revert ("account: invalid nonce");
-        //require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
-    /**
-     * @dev implement template method of BaseAccount
      */
     function _validateSignature(
         UserOperation calldata userOp,

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount11.sol
@@ -202,13 +202,6 @@ contract SmartAccount11 is
     }
 
     /**
-     * @dev Standard interface for 1d nonces. Use it for Account Abstraction flow.
-     */
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
-    /**
      * return the entryPoint used by this account.
      * subclass should return the current entryPoint used by this account.
      */

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
@@ -548,15 +548,6 @@ contract SmartAccount3 is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount3.sol
@@ -159,11 +159,6 @@ contract SmartAccount3 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
@@ -552,15 +552,6 @@ contract SmartAccount4 is
     }
 
     /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
-    /// implement template method of BaseAccount
     function _validateSignature(
         UserOperation calldata userOp,
         bytes32 userOpHash

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount4.sol
@@ -166,11 +166,6 @@ contract SmartAccount4 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
@@ -166,11 +166,6 @@ contract SmartAccount5 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount5.sol
@@ -547,15 +547,6 @@ contract SmartAccount5 is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
@@ -559,15 +559,6 @@ contract SmartAccount7 is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount7.sol
@@ -167,11 +167,6 @@ contract SmartAccount7 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
@@ -168,11 +168,6 @@ contract SmartAccount9 is
         return nonces[batchId];
     }
 
-    // Standard interface for 1d nonces. Use it for Account Abstraction flow.
-    function nonce() public view virtual override returns (uint256) {
-        return nonces[0];
-    }
-
     function entryPoint() public view virtual override returns (IEntryPoint) {
         return _entryPoint;
     }

--- a/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
+++ b/contracts/smart-contract-wallet/test/upgrades/SmartAccount9.sol
@@ -564,15 +564,6 @@ contract SmartAccount9 is
         );
     }
 
-    /// implement template method of BaseAccount
-    // @notice Nonce space is locked to 0 for AA transactions
-    // userOp could have batchId as well
-    function _validateAndUpdateNonce(
-        UserOperation calldata userOp
-    ) internal override {
-        require(nonces[0]++ == userOp.nonce, "account: invalid nonce");
-    }
-
     /**
      * @dev implement template method of BaseAccount
      */

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@0xsequence/create3": "https://github.com/0xsequence/create3",
-    "@account-abstraction/contracts": "^0.5.0",
+    "@account-abstraction/contracts": "^0.6.0",
     "@account-abstraction/sdk": "^0.5.0",
     "@chainlink/contracts": "^0.4.1",
     "@ethersproject/abstract-signer": "^5.6.2",

--- a/test/aa-core/UserOp.ts
+++ b/test/aa-core/UserOp.ts
@@ -15,78 +15,65 @@ import { EntryPoint } from "../../typechain";
 import { UserOperation } from "./UserOperation";
 import { Create2Factory } from "../../src/Create2Factory";
 
-function encode(
-  typevalues: Array<{ type: string; val: any }>,
-  forSignature: boolean
-): string {
-  const types = typevalues.map((typevalue) =>
-    typevalue.type === "bytes" && forSignature ? "bytes32" : typevalue.type
-  );
-  const values = typevalues.map((typevalue) =>
-    typevalue.type === "bytes" && forSignature
-      ? keccak256(typevalue.val)
-      : typevalue.val
-  );
-  return defaultAbiCoder.encode(types, values);
-}
-
-// export function packUserOp(op: UserOperation, hashBytes = true): string {
-//   if ( !hashBytes || true ) {
-//     return packUserOp1(op, hashBytes)
-//   }
-//
-//   const opEncoding = Object.values(testUtil.interface.functions).find(func => func.name == 'packUserOp')!.inputs[0]
-//   let packed = defaultAbiCoder.encode([opEncoding], [{...op, signature:'0x'}])
-//   packed = '0x'+packed.slice(64+2) //skip first dword (length)
-//   packed = packed.slice(0,packed.length-64) //remove signature (the zero-length)
-//   return packed
-// }
-
 export function packUserOp(op: UserOperation, forSignature = true): string {
   if (forSignature) {
-    // lighter signature scheme (must match UserOperation#pack): do encode a zero-length signature, but strip afterwards the appended zero-length value
-    const userOpType = {
-      components: [
-        { type: "address", name: "sender" },
-        { type: "uint256", name: "nonce" },
-        { type: "bytes", name: "initCode" },
-        { type: "bytes", name: "callData" },
-        { type: "uint256", name: "callGasLimit" },
-        { type: "uint256", name: "verificationGasLimit" },
-        { type: "uint256", name: "preVerificationGas" },
-        { type: "uint256", name: "maxFeePerGas" },
-        { type: "uint256", name: "maxPriorityFeePerGas" },
-        { type: "bytes", name: "paymasterAndData" },
-        { type: "bytes", name: "signature" },
+    return defaultAbiCoder.encode(
+      [
+        "address",
+        "uint256",
+        "bytes32",
+        "bytes32",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "bytes32",
       ],
-      name: "userOp",
-      type: "tuple",
-    };
-    let encoded = defaultAbiCoder.encode(
-      [userOpType as any],
-      [{ ...op, signature: "0x" }]
+      [
+        op.sender,
+        op.nonce,
+        keccak256(op.initCode),
+        keccak256(op.callData),
+        op.callGasLimit,
+        op.verificationGasLimit,
+        op.preVerificationGas,
+        op.maxFeePerGas,
+        op.maxPriorityFeePerGas,
+        keccak256(op.paymasterAndData),
+      ]
     );
-    // remove leading word (total length) and trailing word (zero-length signature)
-    encoded = "0x" + encoded.slice(66, encoded.length - 64);
-    return encoded;
+  } else {
+    // for the purpose of calculating gas cost encode also signature (and no keccak of bytes)
+    return defaultAbiCoder.encode(
+      [
+        "address",
+        "uint256",
+        "bytes",
+        "bytes",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "bytes",
+        "bytes",
+      ],
+      [
+        op.sender,
+        op.nonce,
+        op.initCode,
+        op.callData,
+        op.callGasLimit,
+        op.verificationGasLimit,
+        op.preVerificationGas,
+        op.maxFeePerGas,
+        op.maxPriorityFeePerGas,
+        op.paymasterAndData,
+        op.signature,
+      ]
+    );
   }
-  const typevalues = [
-    { type: "address", val: op.sender },
-    { type: "uint256", val: op.nonce },
-    { type: "bytes", val: op.initCode },
-    { type: "bytes", val: op.callData },
-    { type: "uint256", val: op.callGasLimit },
-    { type: "uint256", val: op.verificationGasLimit },
-    { type: "uint256", val: op.preVerificationGas },
-    { type: "uint256", val: op.maxFeePerGas },
-    { type: "uint256", val: op.maxPriorityFeePerGas },
-    { type: "bytes", val: op.paymasterAndData },
-  ];
-  if (!forSignature) {
-    // for the purpose of calculating gas cost, also hash signature
-    typevalues.push({ type: "bytes", val: op.signature });
-  }
-  return encode(typevalues, forSignature);
 }
 
 export function packUserOp1(op: UserOperation): string {
@@ -97,8 +84,8 @@ export function packUserOp1(op: UserOperation): string {
       "bytes32", // initCode
       "bytes32", // callData
       "uint256", // callGasLimit
-      "uint", // verificationGasLimit
-      "uint", // preVerificationGas
+      "uint256", // verificationGasLimit
+      "uint256", // preVerificationGas
       "uint256", // maxFeePerGas
       "uint256", // maxPriorityFeePerGas
       "bytes32", // paymasterAndData
@@ -137,7 +124,7 @@ export const DefaultsForUserOp: UserOperation = {
   initCode: "0x",
   callData: "0x",
   callGasLimit: 0,
-  verificationGasLimit: 100000, // default verification gas. will add create2 cost (3200+200*length) if initCode exists
+  verificationGasLimit: 150000, // default verification gas. will add create2 cost (3200+200*length) if initCode exists
   preVerificationGas: 21000, // should also cover calldata cost.
   maxFeePerGas: 0,
   maxPriorityFeePerGas: 1e9,
@@ -193,15 +180,16 @@ export function fillUserOpDefaults(
 //  - calculate sender by eth_call the deployment code
 //  - default verificationGasLimit estimateGas of deployment code plus default 100000
 // no initCode:
-//  - update nonce from account.nonce()
+//  - update nonce from account.getNonce()
 // entryPoint param is only required to fill in "sender address when specifying "initCode"
-// nonce: assume contract as "nonce()" function, and fill in.
+// nonce: assume contract as "getNonce()" function, and fill in.
 // sender - only in case of construction: fill sender from initCode.
 // callGasLimit: VERY crude estimation (by estimating call to account, and add rough entryPoint overhead
 // verificationGasLimit: hard-code default at 100k. should add "create2" cost
 export async function fillUserOp(
   op: Partial<UserOperation>,
-  entryPoint?: EntryPoint
+  entryPoint?: EntryPoint,
+  getNonceFunction = "getNonce"
 ): Promise<UserOperation> {
   const op1 = { ...op };
   const provider = entryPoint?.provider;
@@ -243,23 +231,23 @@ export async function fillUserOp(
       throw new Error("must have entryPoint to autofill nonce");
     const c = new Contract(
       op.sender!,
-      ["function nonce() view returns(address)"],
+      [`function ${getNonceFunction}() view returns(uint256)`],
       provider
     );
-    op1.nonce = await c.nonce().catch(rethrow());
+    op1.nonce = await c[getNonceFunction]().catch(rethrow());
   }
   if (op1.callGasLimit == null && op.callData != null) {
     if (provider == null)
       throw new Error("must have entryPoint for callGasLimit estimate");
-    const gasEstimated = await provider.estimateGas({
+    const gasEtimated = await provider.estimateGas({
       from: entryPoint?.address,
       to: op1.sender,
       data: op1.callData,
     });
 
-    // console.log('estim', op1.sender,'len=', op1.callData!.length, 'res=', gasEstimated)
+    // console.log('estim', op1.sender,'len=', op1.callData!.length, 'res=', gasEtimated)
     // estimateGas assumes direct call from entryPoint. add wrapper cost.
-    op1.callGasLimit = gasEstimated; // .add(55000)
+    op1.callGasLimit = gasEtimated; // .add(55000)
   }
   if (op1.maxFeePerGas == null) {
     if (provider == null)
@@ -286,10 +274,11 @@ export async function fillUserOp(
 export async function fillAndSign(
   op: Partial<UserOperation>,
   signer: Wallet | Signer,
-  entryPoint?: EntryPoint
+  entryPoint?: EntryPoint,
+  getNonceFunction = "getNonce"
 ): Promise<UserOperation> {
   const provider = entryPoint?.provider;
-  const op2 = await fillUserOp(op, entryPoint);
+  const op2 = await fillUserOp(op, entryPoint, getNonceFunction);
 
   const chainId = await provider!.getNetwork().then((net) => net.chainId);
   const message = arrayify(getUserOpHash(op2, entryPoint!.address, chainId));

--- a/test/module/aa-module.specs.ts
+++ b/test/module/aa-module.specs.ts
@@ -65,7 +65,8 @@ async function getUserOpWithPaymasterData(
       ]),
     },
     walletOwner,
-    entryPoint
+    entryPoint,
+    'nonce'
   );
   return userOpWithPaymasterData;
 }
@@ -189,7 +190,8 @@ describe("Module transactions via AA flow", function () {
           verificationGasLimit: 350000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       // Set paymaster data in UserOp
@@ -244,7 +246,8 @@ describe("Module transactions via AA flow", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       // Set paymaster data in UserOp
@@ -335,7 +338,8 @@ describe("Module transactions via AA flow", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       // Set paymaster data in UserOp
@@ -605,7 +609,8 @@ describe("Module transactions via AA flow", function () {
           // no callGasLImit override as wallet is deployed
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       const hash = await verifyingSingletonPaymaster.getHash(
@@ -625,7 +630,8 @@ describe("Module transactions via AA flow", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
       console.log(userOp);
       // const userOpHash = await entryPoint.getUserOpHash(userOp);
@@ -709,7 +715,8 @@ describe("Module transactions via AA flow", function () {
           // no callGasLImit override as wallet is deployed
         },
         accounts[7], // not an owner // as good as overriding later with fake sig!
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       const hash = await verifyingSingletonPaymaster.getHash(
@@ -729,7 +736,8 @@ describe("Module transactions via AA flow", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
       console.log(userOp);
       // TODO: Replace signature with mock signature..
@@ -807,7 +815,8 @@ describe("Module transactions via AA flow", function () {
           // no callGasLImit override as wallet is deployed
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       const hash = await verifyingSingletonPaymaster.getHash(
@@ -827,7 +836,8 @@ describe("Module transactions via AA flow", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
       console.log(userOpAA1);
       await entryPoint.handleOps(
@@ -881,7 +891,8 @@ describe("Module transactions via AA flow", function () {
           // no callGasLImit override as wallet is deployed
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       const hash2 = await verifyingSingletonPaymaster.getHash(
@@ -901,7 +912,8 @@ describe("Module transactions via AA flow", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
       console.log(userOpAA2);
       await entryPoint.handleOps(
@@ -1008,7 +1020,8 @@ describe("Module transactions via AA flow", function () {
           // no callGasLImit override as wallet is deployed
         },
         accounts[8], // not an owner
-        entryPoint
+        entryPoint,
+        'nonce'
       );
 
       const hash = await verifyingSingletonPaymaster.getHash(
@@ -1028,7 +1041,8 @@ describe("Module transactions via AA flow", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        'nonce'
       );
       console.log(userOp);
       // TODO: Replace signature with mock signature..

--- a/test/module/aa-module.specs.ts
+++ b/test/module/aa-module.specs.ts
@@ -47,13 +47,8 @@ async function getUserOpWithPaymasterData(
   walletOwner: Signer,
   entryPoint: EntryPoint
 ) {
-  const nonceFromContract = await paymaster["getSenderPaymasterNonce(address)"](
-    smartAccountAddress
-  );
-
   const hash = await paymaster.getHash(
     userOp,
-    nonceFromContract.toNumber(),
     await offchainPaymasterSigner.getAddress()
   );
   const sig = await offchainPaymasterSigner.signMessage(arrayify(hash));
@@ -613,13 +608,8 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
 
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](expectedSmartAccountAddress);
-
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -722,13 +712,8 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
 
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](expectedSmartAccountAddress);
-
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -825,13 +810,8 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
 
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](expectedSmartAccountAddress);
-
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -904,13 +884,8 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
 
-      const nonceFromContract2 = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](expectedSmartAccountAddress);
-
       const hash2 = await verifyingSingletonPaymaster.getHash(
         userOp2,
-        nonceFromContract2.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig2 = await offchainSigner.signMessage(arrayify(hash2));
@@ -1036,13 +1011,8 @@ describe("Module transactions via AA flow", function () {
         entryPoint
       );
 
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](expectedSmartAccountAddress);
-
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress() // paymaster id is still same as previous offchain signer
       );
       const sig = await offchainSigner2.signMessage(arrayify(hash));

--- a/test/paymaster/singleton/paymaster-accounting.ts
+++ b/test/paymaster/singleton/paymaster-accounting.ts
@@ -243,7 +243,8 @@ async function getUserOpWithInitCodeAndPaymasterData(
     },
     walletOwner,
     entryPoint,
-    21685 // _validateAccountAndPaymasterValidationData + compensate + anything unaccounted
+    "nonce",
+    31685 // _validateAccountAndPaymasterValidationData + compensate + anything unaccounted
   );
 
   // Set paymaster data in UserOp
@@ -277,15 +278,7 @@ async function getUserOpWithPaymasterData(
   walletOwner: Signer,
   entryPoint: EntryPoint
 ) {
-  const nonceFromContract = await paymaster["getSenderPaymasterNonce(address)"](
-    smartAccountAddress
-  );
-
-  const hash = await paymaster.getHash(
-    userOp,
-    nonceFromContract.toNumber(),
-    paymasterId
-  );
+  const hash = await paymaster.getHash(userOp, paymasterId);
   const sig = await offchainPaymasterSigner.signMessage(arrayify(hash));
   const userOpWithPaymasterData = await fillAndSign(
     {
@@ -300,7 +293,8 @@ async function getUserOpWithPaymasterData(
       ]),
     },
     walletOwner,
-    entryPoint
+    entryPoint,
+    "nonce"
   );
   return userOpWithPaymasterData;
 }

--- a/test/paymaster/singleton/verifying-singleton-paymaster.ts
+++ b/test/paymaster/singleton/verifying-singleton-paymaster.ts
@@ -115,22 +115,12 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
         sender: walletAddress,
       },
       walletOwner,
-      entryPoint
+      entryPoint,
+      "nonce"
     );
-
-    const nonceFromContract = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce(address)"
-    ](walletAddress);
-
-    const nonceFromContract1 = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce((address,uint256,bytes,bytes,uint256,uint256,uint256,uint256,uint256,bytes,bytes))"
-    ](userOp1);
-
-    expect(nonceFromContract).to.be.equal(nonceFromContract1);
 
     const hash = await verifyingSingletonPaymaster.getHash(
       userOp1,
-      nonceFromContract.toNumber(),
       paymasterId
     );
     const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -142,7 +132,8 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
         paymasterAndData,
       },
       walletOwner,
-      entryPoint
+      entryPoint,
+      "nonce"
     );
   }
 
@@ -173,16 +164,12 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
-
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](walletAddress);
 
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -198,7 +185,8 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
       await entryPoint.handleOps([userOp], await offchainSigner.getAddress());
       await expect(
@@ -206,7 +194,7 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
       ).to.be.reverted;
     });
 
-    it("signature replay", async () => {
+    /* it("signature replay", async () => {
       console.log("Paymaster Signed for good sender😇");
       await verifyingSingletonPaymaster.depositFor(
         await offchainSigner.getAddress(),
@@ -218,15 +206,12 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
-      const nonceFromContract = await verifyingSingletonPaymaster[
-        "getSenderPaymasterNonce(address)"
-      ](walletAddress);
 
       const hash = await verifyingSingletonPaymaster.getHash(
         userOp1,
-        nonceFromContract.toNumber(),
         await offchainSigner.getAddress()
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -265,12 +250,13 @@ describe("EntryPoint with VerifyingPaymaster Singleton", function () {
           ]),
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
       await entryPoint.handleOps([userOp], await offchainSigner.getAddress());
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())
       ).to.be.reverted;
-    });
+    }); */
   });
 });

--- a/test/smart-wallet/aa-upgrades-all-flows.ts
+++ b/test/smart-wallet/aa-upgrades-all-flows.ts
@@ -59,7 +59,8 @@ async function getUserOpWithPaymasterData(
       ]),
     },
     walletOwner,
-    entryPoint
+    entryPoint,
+    "nonce"
   );
   return userOpWithPaymasterData;
 }
@@ -160,7 +161,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           verificationGasLimit: 350000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -215,7 +217,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -279,7 +282,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           verificationGasLimit: 200000,
         },
         walletOwner,
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -368,7 +372,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           // callGasLimit: 1000000,
         },
         accounts[5], // since the owner has changed!
-        entryPoint
+        entryPoint,
+        "nonce"
       );
       // Set paymaster data in UserOp
       const userOp = await getUserOpWithPaymasterData(
@@ -534,7 +539,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           callGasLimit: 1000000,
         },
         walletOwner, // since the owner signer is supposed to be walletOwner
-        entryPoint // at this point original entrypoint should process userops
+        entryPoint, // at this point original entrypoint should process userops
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -584,7 +590,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           verificationGasLimit: 350000,
         },
         walletOwner, // rightful owner signer
-        entryPoint // previous entrypoint
+        entryPoint, // previous entrypoint
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -625,7 +632,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           verificationGasLimit: 350000,
         },
         walletOwner, // rightful owner signer
-        latestEntryPoint // previous entrypoint
+        latestEntryPoint, // previous entrypoint
+        "nonce"
       );
 
       // NOTICE: To use the latestEntryPoint now you mus make the deposits (migrate stakes and deposits!)
@@ -740,7 +748,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           callGasLimit: 1000000,
         },
         walletOwner, // since the owner signer is supposed to be walletOwner
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -840,7 +849,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           callGasLimit: 1000000,
         },
         walletOwner, // since the owner signer is supposed to be walletOwner
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -948,7 +958,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           callGasLimit: 1000000,
         },
         walletOwner, // since the owner signer is supposed to be walletOwner
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp
@@ -1097,7 +1108,8 @@ describe("Upgrade functionality Via Entrypoint", function () {
           callGasLimit: 1000000,
         },
         walletOwner, // since the owner signer is supposed to be walletOwner
-        entryPoint
+        entryPoint,
+        "nonce"
       );
 
       // Set paymaster data in UserOp

--- a/test/smart-wallet/aa-upgrades-all-flows.ts
+++ b/test/smart-wallet/aa-upgrades-all-flows.ts
@@ -41,13 +41,8 @@ async function getUserOpWithPaymasterData(
   walletOwner: Signer,
   entryPoint: EntryPoint
 ) {
-  const nonceFromContract = await paymaster["getSenderPaymasterNonce(address)"](
-    smartAccountAddress
-  );
-
   const hash = await paymaster.getHash(
     userOp,
-    nonceFromContract.toNumber(),
     await offchainPaymasterSigner.getAddress()
   );
   const sig = await offchainPaymasterSigner.signMessage(arrayify(hash));

--- a/test/smart-wallet/estimations.ts
+++ b/test/smart-wallet/estimations.ts
@@ -160,11 +160,10 @@ describe("Account Functionality: 4337", function () {
       ethers.utils.parseEther("1"),
     ]);
     // encode executeCall function data with transfer erc20 token data
-    const txnData = SmartAccount.interface.encodeFunctionData("executeCall_s1m", [
-      token.address,
-      0,
-      transferData,
-    ]);
+    const txnData = SmartAccount.interface.encodeFunctionData(
+      "executeCall_s1m",
+      [token.address, 0, transferData]
+    );
 
     const userOp1 = await fillAndSign(
       {
@@ -173,7 +172,8 @@ describe("Account Functionality: 4337", function () {
         verificationGasLimit: 200000,
       },
       walletOwner,
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const hash = await verifyingSingletonPaymaster.getHash(
@@ -193,7 +193,8 @@ describe("Account Functionality: 4337", function () {
         ]),
       },
       walletOwner,
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const tx = await entryPoint.handleOps(
@@ -239,11 +240,10 @@ describe("Account Functionality: 4337", function () {
       ethers.utils.parseEther("1"),
     ]);
     // encode executeCall function data with transfer erc20 token data
-    const txnData = SmartAccount.interface.encodeFunctionData("executeCall_s1m", [
-      token.address,
-      0,
-      transferData,
-    ]);
+    const txnData = SmartAccount.interface.encodeFunctionData(
+      "executeCall_s1m",
+      [token.address, 0, transferData]
+    );
 
     const WalletFactory = await ethers.getContractFactory(
       "SmartAccountFactory"
@@ -263,7 +263,8 @@ describe("Account Functionality: 4337", function () {
         initCode: hexConcat([walletFactory.address, encodedData]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const hash = await verifyingSingletonPaymaster.getHash(
@@ -283,7 +284,8 @@ describe("Account Functionality: 4337", function () {
         ]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const tx = await entryPoint.handleOps(
@@ -352,7 +354,8 @@ describe("Account Functionality: 4337", function () {
         // initCode: hexConcat([walletFactory.address, encodedData]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const hash = await verifyingSingletonPaymaster.getHash(
@@ -372,7 +375,8 @@ describe("Account Functionality: 4337", function () {
         ]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const tx = await entryPoint.handleOps(
@@ -451,7 +455,8 @@ describe("Account Functionality: 4337", function () {
         initCode: hexConcat([walletFactory.address, encodedData]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const hash = await verifyingSingletonPaymaster.getHash(
@@ -471,7 +476,8 @@ describe("Account Functionality: 4337", function () {
         ]),
       },
       accounts[2],
-      entryPoint
+      entryPoint,
+      "nonce"
     );
 
     const tx = await entryPoint.handleOps(
@@ -615,7 +621,7 @@ describe("Account Functionality: 4337", function () {
       `Forward flow: [send erc20] tx execTransaction_S6W: ${receipt.gasUsed.toString()}`
     );
 
-    console.log(token.balanceOf(john));
+    console.log(await token.balanceOf(john));
     expect(await token.balanceOf(john)).to.equal(ethers.utils.parseEther("5"));
   });
 

--- a/test/smart-wallet/estimations.ts
+++ b/test/smart-wallet/estimations.ts
@@ -175,13 +175,9 @@ describe("Account Functionality: 4337", function () {
       walletOwner,
       entryPoint
     );
-    const nonceFromContract = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce(address)"
-    ](walletAddress);
 
     const hash = await verifyingSingletonPaymaster.getHash(
       userOp1,
-      nonceFromContract.toNumber(),
       await offchainSigner.getAddress()
     );
     const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -269,12 +265,9 @@ describe("Account Functionality: 4337", function () {
       accounts[2],
       entryPoint
     );
-    const nonceFromContract = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce(address)"
-    ](newUserSCW.address);
+
     const hash = await verifyingSingletonPaymaster.getHash(
       userOp1,
-      nonceFromContract.toNumber(),
       await offchainSigner.getAddress()
     );
     const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -362,13 +355,8 @@ describe("Account Functionality: 4337", function () {
       entryPoint
     );
 
-    const nonceFromContract = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce(address)"
-    ](newUserSCW.address);
-
     const hash = await verifyingSingletonPaymaster.getHash(
       userOp1,
-      nonceFromContract.toNumber(),
       await offchainSigner.getAddress()
     );
     const sig = await offchainSigner.signMessage(arrayify(hash));
@@ -466,13 +454,8 @@ describe("Account Functionality: 4337", function () {
       entryPoint
     );
 
-    const nonceFromContract = await verifyingSingletonPaymaster[
-      "getSenderPaymasterNonce(address)"
-    ](newUserSCW.address);
-
     const hash = await verifyingSingletonPaymaster.getHash(
       userOp1,
-      nonceFromContract.toNumber(),
       await offchainSigner.getAddress()
     );
     const sig = await offchainSigner.signMessage(arrayify(hash));

--- a/test/utils/userOp.ts
+++ b/test/utils/userOp.ts
@@ -7,94 +7,75 @@ import {
   keccak256,
 } from "ethers/lib/utils";
 import { BigNumber, Contract, Signer, Wallet } from "ethers";
-import {
-  AddressZero,
-  callDataCost,
-  HashZero,
-  rethrow,
-} from "../smart-wallet/testutils";
+import { AddressZero, callDataCost, HashZero, rethrow } from "../smart-wallet/testutils";
 import {
   ecsign,
   toRpcSig,
   keccak256 as keccak256_buffer,
 } from "ethereumjs-util";
-import { ethers } from "hardhat";
-import { EntryPoint, VerifyingPaymaster } from "../../typechain";
-import { UserOperation } from "./userOpetation";
+import { EntryPoint } from "../../typechain";
+import { UserOperation } from "./UserOperation";
 import { Create2Factory } from "../../src/Create2Factory";
-
-function encode(
-  typevalues: Array<{ type: string; val: any }>,
-  forSignature: boolean
-): string {
-  const types = typevalues.map((typevalue) =>
-    typevalue.type === "bytes" && forSignature ? "bytes32" : typevalue.type
-  );
-  const values = typevalues.map((typevalue) =>
-    typevalue.type === "bytes" && forSignature
-      ? keccak256(typevalue.val)
-      : typevalue.val
-  );
-  return defaultAbiCoder.encode(types, values);
-}
-
-// export function packUserOp(op: UserOperation, hashBytes = true): string {
-//   if ( !hashBytes || true ) {
-//     return packUserOp1(op, hashBytes)
-//   }
-//
-//   const opEncoding = Object.values(testUtil.interface.functions).find(func => func.name == 'packUserOp')!.inputs[0]
-//   let packed = defaultAbiCoder.encode([opEncoding], [{...op, signature:'0x'}])
-//   packed = '0x'+packed.slice(64+2) //skip first dword (length)
-//   packed = packed.slice(0,packed.length-64) //remove signature (the zero-length)
-//   return packed
-// }
 
 export function packUserOp(op: UserOperation, forSignature = true): string {
   if (forSignature) {
-    // lighter signature scheme (must match UserOperation#pack): do encode a zero-length signature, but strip afterwards the appended zero-length value
-    const userOpType = {
-      components: [
-        { type: "address", name: "sender" },
-        { type: "uint256", name: "nonce" },
-        { type: "bytes", name: "initCode" },
-        { type: "bytes", name: "callData" },
-        { type: "uint256", name: "callGasLimit" },
-        { type: "uint256", name: "verificationGasLimit" },
-        { type: "uint256", name: "preVerificationGas" },
-        { type: "uint256", name: "maxFeePerGas" },
-        { type: "uint256", name: "maxPriorityFeePerGas" },
-        { type: "bytes", name: "paymasterAndData" },
-        { type: "bytes", name: "signature" },
+    return defaultAbiCoder.encode(
+      [
+        "address",
+        "uint256",
+        "bytes32",
+        "bytes32",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "bytes32",
       ],
-      name: "userOp",
-      type: "tuple",
-    };
-    let encoded = defaultAbiCoder.encode(
-      [userOpType as any],
-      [{ ...op, signature: "0x" }]
+      [
+        op.sender,
+        op.nonce,
+        keccak256(op.initCode),
+        keccak256(op.callData),
+        op.callGasLimit,
+        op.verificationGasLimit,
+        op.preVerificationGas,
+        op.maxFeePerGas,
+        op.maxPriorityFeePerGas,
+        keccak256(op.paymasterAndData),
+      ]
     );
-    // remove leading word (total length) and trailing word (zero-length signature)
-    encoded = "0x" + encoded.slice(66, encoded.length - 64);
-    return encoded;
+  } else {
+    // for the purpose of calculating gas cost encode also signature (and no keccak of bytes)
+    return defaultAbiCoder.encode(
+      [
+        "address",
+        "uint256",
+        "bytes",
+        "bytes",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "uint256",
+        "bytes",
+        "bytes",
+      ],
+      [
+        op.sender,
+        op.nonce,
+        op.initCode,
+        op.callData,
+        op.callGasLimit,
+        op.verificationGasLimit,
+        op.preVerificationGas,
+        op.maxFeePerGas,
+        op.maxPriorityFeePerGas,
+        op.paymasterAndData,
+        op.signature,
+      ]
+    );
   }
-  const typevalues = [
-    { type: "address", val: op.sender },
-    { type: "uint256", val: op.nonce },
-    { type: "bytes", val: op.initCode },
-    { type: "bytes", val: op.callData },
-    { type: "uint256", val: op.callGasLimit },
-    { type: "uint256", val: op.verificationGasLimit },
-    { type: "uint256", val: op.preVerificationGas },
-    { type: "uint256", val: op.maxFeePerGas },
-    { type: "uint256", val: op.maxPriorityFeePerGas },
-    { type: "bytes", val: op.paymasterAndData },
-  ];
-  if (!forSignature) {
-    // for the purpose of calculating gas cost, also hash signature
-    typevalues.push({ type: "bytes", val: op.signature });
-  }
-  return encode(typevalues, forSignature);
 }
 
 export function packUserOp1(op: UserOperation): string {
@@ -145,8 +126,8 @@ export const DefaultsForUserOp: UserOperation = {
   initCode: "0x",
   callData: "0x",
   callGasLimit: 0,
-  verificationGasLimit: 100000, // default verification gas. will add create2 cost (3200+200*length) if initCode exists
-  preVerificationGas: 0, // should also cover calldata cost.
+  verificationGasLimit: 150000, // default verification gas. will add create2 cost (3200+200*length) if initCode exists
+  preVerificationGas: 21000, // should also cover calldata cost.
   maxFeePerGas: 0,
   maxPriorityFeePerGas: 1e9,
   paymasterAndData: "0x",
@@ -196,20 +177,21 @@ export function fillUserOpDefaults(
 }
 
 // helper to fill structure:
-// - default callGasLimit to estimate call from entryPoint to wallet (TODO: add overhead)
+// - default callGasLimit to estimate call from entryPoint to account (TODO: add overhead)
 // if there is initCode:
 //  - calculate sender by eth_call the deployment code
 //  - default verificationGasLimit estimateGas of deployment code plus default 100000
 // no initCode:
-//  - update nonce from wallet.nonce()
+//  - update nonce from account.getNonce()
 // entryPoint param is only required to fill in "sender address when specifying "initCode"
-// nonce: assume contract as "nonce()" function, and fill in.
+// nonce: assume contract as "getNonce()" function, and fill in.
 // sender - only in case of construction: fill sender from initCode.
-// callGasLimit: VERY crude estimation (by estimating call to wallet, and add rough entryPoint overhead
+// callGasLimit: VERY crude estimation (by estimating call to account, and add rough entryPoint overhead
 // verificationGasLimit: hard-code default at 100k. should add "create2" cost
 export async function fillUserOp(
   op: Partial<UserOperation>,
-  entryPoint?: EntryPoint
+  entryPoint?: EntryPoint,
+  getNonceFunction = "getNonce"
 ): Promise<UserOperation> {
   const op1 = { ...op };
   const provider = entryPoint?.provider;
@@ -218,15 +200,13 @@ export async function fillUserOp(
     const initCallData = hexDataSlice(op1.initCode!, 20);
     if (op1.nonce == null) op1.nonce = 0;
     if (op1.sender == null) {
-      // hack: if the init contract is our deployer, then we know what the address would be, without a view call
+      // hack: if the init contract is our known deployer, then we know what the address would be, without a view call
       if (
         initAddr.toLowerCase() === Create2Factory.contractAddress.toLowerCase()
       ) {
-        const [ctr] = defaultAbiCoder.decode(
-          ["bytes", "bytes32"],
-          "0x" + initCallData.slice(10)
-        );
-        op1.sender = getCreate2Address(initAddr, HashZero, keccak256(ctr));
+        const ctr = hexDataSlice(initCallData, 32);
+        const salt = hexDataSlice(initCallData, 0, 32);
+        op1.sender = Create2Factory.getDeployedAddress(ctr, salt);
       } else {
         // console.log('\t== not our deployer. our=', Create2Factory.contractAddress, 'got', initAddr)
         if (provider == null) throw new Error("no entrypoint/provider");
@@ -253,24 +233,23 @@ export async function fillUserOp(
       throw new Error("must have entryPoint to autofill nonce");
     const c = new Contract(
       op.sender!,
-      ["function nonce() view returns(uint256)"],
+      [`function ${getNonceFunction}() view returns(uint256)`],
       provider
     );
-    op1.nonce = await c.nonce().catch(rethrow());
+    op1.nonce = await c[getNonceFunction]().catch(rethrow());
   }
   if (op1.callGasLimit == null && op.callData != null) {
     if (provider == null)
       throw new Error("must have entryPoint for callGasLimit estimate");
-    const gasEstimated = await provider.estimateGas({
+    const gasEtimated = await provider.estimateGas({
       from: entryPoint?.address,
       to: op1.sender,
       data: op1.callData,
     });
 
-    // console.log('estim', op1.sender,'len=', op1.callData!.length, 'res=', gasEstimated)
+    // console.log('estim', op1.sender,'len=', op1.callData!.length, 'res=', gasEtimated)
     // estimateGas assumes direct call from entryPoint. add wrapper cost.
-    op1.callGasLimit = gasEstimated; // .add(55000)
-    console.log("call gas estimated ", gasEstimated);
+    op1.callGasLimit = gasEtimated; // .add(55000)
   }
   if (op1.maxFeePerGas == null) {
     if (provider == null)
@@ -289,7 +268,7 @@ export async function fillUserOp(
   // eslint-disable-next-line @typescript-eslint/no-base-to-string
   if (op2.preVerificationGas.toString() === "0") {
     // TODO: we don't add overhead, which is ~21000 for a single TX, but much lower in a batch.
-    op2.preVerificationGas = callDataCost(packUserOp(op2, false)) + 21000;
+    op2.preVerificationGas = callDataCost(packUserOp(op2, false));
   }
   return op2;
 }
@@ -298,34 +277,19 @@ export async function fillAndSign(
   op: Partial<UserOperation>,
   signer: Wallet | Signer,
   entryPoint?: EntryPoint,
+  getNonceFunction = "getNonce",
   extraPreVerificationGas: number = 0
 ): Promise<UserOperation> {
   const provider = entryPoint?.provider;
-  const op2 = await fillUserOp(op, entryPoint);
+  const op2 = await fillUserOp(op, entryPoint, getNonceFunction);
   op2.preVerificationGas =
     Number(op2.preVerificationGas) + extraPreVerificationGas;
 
-  const SmartAccount = await ethers.getContractFactory("SmartAccount");
-  const userOpHash = await entryPoint?.getUserOpHash(op2);
   const chainId = await provider!.getNetwork().then((net) => net.chainId);
   const message = arrayify(getUserOpHash(op2, entryPoint!.address, chainId));
-  const userOpSignature = await signer.signMessage(message);
-  op2.signature = userOpSignature;
 
-  const validateUserOpData = SmartAccount.interface.encodeFunctionData(
-    "validateUserOp",
-    [op2, userOpHash, 10]
-  );
-
-  /*
-  const gasEstimatedValidateUserOp = await provider.estimateGas({
-    from: entryPoint?.address,
-    to: op2.sender,
-    data: validateUserOpData, // validateUserOp calldata
-  });
-  
-  console.log("Gaslimit for validate userOp is: ", gasEstimatedValidateUserOp);
-  */
-
-  return op2;
+  return {
+    ...op2,
+    signature: await signer.signMessage(message),
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,6 +13,11 @@
   resolved "https://registry.npmjs.org/@account-abstraction/contracts/-/contracts-0.5.0.tgz"
   integrity sha512-CKyS9Zh5rcYUM+4B6TlaB9+THHzJ+6TY3tWF5QofqvFpqGNvIhF8ddy6wyCmqZw6TB74/yYv7cYD/RarVudfDg==
 
+"@account-abstraction/contracts@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@account-abstraction/contracts/-/contracts-0.6.0.tgz#7188a01839999226e6b2796328af338329543b76"
+  integrity sha512-8ooRJuR7XzohMDM4MV34I12Ci2bmxfE9+cixakRL7lA4BAwJKQ3ahvd8FbJa9kiwkUPCUNtj+/zxDQWYYalLMQ==
+
 "@account-abstraction/sdk@^0.5.0":
   version "0.5.0"
   resolved "https://registry.npmjs.org/@account-abstraction/sdk/-/sdk-0.5.0.tgz"


### PR DESCRIPTION
1. BaseSmartAccount implements nonce() method to get nonce from EntryPoint

```
/**
     * @return nonce the account nonce.
     * @dev This method returns the next sequential nonce.
     * @notice For a nonce of a specific key, use `entrypoint.getNonce(account, key)`
     */
    function nonce() public view virtual returns (uint256) {
        return entryPoint().getNonce(address(this), 0);
    }
```

2. Remove function _validateAndUpdateNonce from BaseSmartAccount and SmartAccount (and all it's versions used for tests)


3. Add below function in abstract class BaseSmartAccount.sol
   function _validateNonce(uint256 nonce) internal view virtual {
    } 
    
 4. Remove below snippet from validateUserOp
 
  ```
 if (userOp.initCode.length == 0) {	
            _validateAndUpdateNonce(userOp);	
        }
```

5. Remove senderNonce from VerifyingSingletonPaymaster

rationale: 

The reason for adding a nonce to the paymaster was to handle cases where the nonce was not unique: a wallet could support static nonce, and it could re-use the VerifyingPaymaster validation multiple times.
But now nonces uniqueness is validated by entrypoint. So a paymaster no longer need to check for uniqueness by itself

6. remove nonce() method from SmartAccount.sol (and all it's versions used for tests) because it's already implemented in abstract BaseAccount 

7. no need for senderPaymasterNonce while signing for VerifyingSingletonPaymaster
