### PR TITLE
Ownership modules refactoring and optimizations

### DIFF
--- a/contracts/smart-contract-wallet/SmartAccount.sol
+++ b/contracts/smart-contract-wallet/SmartAccount.sol
@@ -265,7 +265,8 @@ contract SmartAccount is
             userOp.signature,
             (bytes, address)
         );
-        // TODO: USE if(isModuleEnabled()) instead?
+        // TODO:
+        // 1) USE if(isModuleEnabled()) instead?
         // It's more expensive but handles the SENTINEL_MODULES case
         // However, validationModule.validateUserOp reverts if sentinel module is provided as a validation module
         // Can there be the case, when SENTINEL_MODULES.validateUserOp won't revert, leaving validation data 0

--- a/contracts/smart-contract-wallet/modules/Exotic/EcdsaEthSignSupportOwnershipRegistryModule.sol
+++ b/contracts/smart-contract-wallet/modules/Exotic/EcdsaEthSignSupportOwnershipRegistryModule.sol
@@ -80,20 +80,12 @@ contract EcdsaWithEthSignSupportOwnershipRegistryModule is
             userOp.signature,
             (bytes, address)
         );
-        // validateUserOp gets a hash not prepended with 'x\x19Ethereum Signed Message:\n32'
-        // so we have to do it manually
-        bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
-        return _validateSignature(userOp, ethSignedHash, moduleSignature);
-    }
-
-    function _validateSignature(
-        UserOperation calldata userOp,
-        bytes32 ethSignedUserOpHash,
-        bytes memory moduleSignature
-    ) internal view virtual returns (uint256 sigValidationResult) {
+        // validateUserOp gets from EP a hash not prepended with 'x\x19Ethereum Signed Message:\n32'
+        // so we have to do it manually, as on the user side it is signed with personal_sign
+        // that prepends with "\x19Ethereum Signed Message\n32"
         if (
             _verifySignature(
-                ethSignedUserOpHash,
+                userOpHash.toEthSignedMessageHash(),
                 moduleSignature,
                 userOp.sender
             )

--- a/contracts/smart-contract-wallet/modules/ForwardFlowModule.sol
+++ b/contracts/smart-contract-wallet/modules/ForwardFlowModule.sol
@@ -61,13 +61,15 @@ contract ForwardFlowModule is ReentrancyGuard, ISignatureValidatorConstants {
     }
 
     /**
-     * @dev Gnosis style transaction with optional repay in native tokens OR ERC20
+     * @dev Safe (ex-Gnosis) style transaction with optional repay in native tokens or ERC20
      * @dev Allows to execute a transaction confirmed by required signature/s and then pays the account that submitted the transaction.
      * @dev Function name optimized to have hash started with zeros to make this function calls cheaper
      * @notice The fees are always transferred, even if the user transaction fails.
      * @param _tx Smart Account transaction
      * @param refundInfo Required information for gas refunds
      * @param signatures Packed signature/s data ({bytes32 r}{bytes32 s}{uint8 v})
+     *                   Should be a signature over Typed Data Hash
+     *                   Use eth_signTypedData, not a personal_sign
      */
 
     function execTransaction(

--- a/contracts/smart-contract-wallet/modules/SmartContractOwnershipRegistryModule.sol
+++ b/contracts/smart-contract-wallet/modules/SmartContractOwnershipRegistryModule.sol
@@ -73,24 +73,12 @@ contract SmartContractOwnershipRegistryModule is BaseAuthorizationModule {
             userOp.signature,
             (bytes, address)
         );
-        // validateUserOp gets a hash not prepended with 'x\x19Ethereum Signed Message:\n32'
-        // so we have to do it manually
-        bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
-        return _validateSignature(userOp, ethSignedHash, moduleSignature);
-    }
-
-    function _validateSignature(
-        UserOperation calldata userOp,
-        bytes32 ethSignedUserOpHash,
-        bytes memory moduleSignature
-    ) internal view virtual returns (uint256 sigValidationResult) {
-        if (
-            _verifySignature(
-                ethSignedUserOpHash,
-                moduleSignature,
-                userOp.sender
-            )
-        ) {
+        // we send exactly the hash that has been received from EP
+        // as in theory owner.isValidSignature can expect signatures not only
+        // over eth signed hash. So if the frontend/backend creates a signature for
+        // this module, it is in charge to provide a signature over the non-modified hash
+        // or over a hash that is modiefied in the way owner expects
+        if (_verifySignature(userOpHash, moduleSignature, userOp.sender)) {
             return 0;
         }
         return SIG_VALIDATION_FAILED;
@@ -99,7 +87,6 @@ contract SmartContractOwnershipRegistryModule is BaseAuthorizationModule {
     /**
      * @dev Validates a signature for a message.
      * To be called from a Smart Account.
-     * Expects a hash prepended with 'x\x19Ethereum Signed Message:\n32'
      * @param dataHash Exact hash of the data that was signed.
      * @param moduleSignature Signature to be validated.
      * @return EIP1271_MAGIC_VALUE if signature is valid, 0xffffffff otherwise.

--- a/test/module/ForwardFlow.Module.specs.ts
+++ b/test/module/ForwardFlow.Module.specs.ts
@@ -243,45 +243,13 @@ describe("NEW::: Forward Flow Module", async () => {
     
   });
 
+  /*
   it("Can process Personal-signed txn", async () => {
-    const { 
-      mockToken,
-      userSA,
-      ecdsaModule
-    } = await setupTests();
-    
-    const charlieTokenBalanceBefore = await mockToken.balanceOf(charlie.address);
-    const tokenAmountToTransfer = ethers.utils.parseEther("0.13924");
-    
-    const safeTx: SafeTransaction = buildSafeTransaction({
-      to: mockToken.address,
-      data: encodeTransfer(charlie.address, tokenAmountToTransfer.toString()),
-      nonce: await forwardFlowModule.getNonce(FORWARD_FLOW),
-    });
-
-    const chainId = await forwardFlowModule.getChainId();
-    const { signer, data } = await safeSignMessage(
-      smartAccountOwner,
-      userSA,
-      safeTx,
-      chainId
-    );
-
-    const {transaction, refundInfo} = getTransactionAndRefundInfoFromSafeTransactionObject(safeTx);
-
-    let signature = "0x";
-    signature += data.slice(2);
-    
-    let signatureWithModuleAddress = ethers.utils.defaultAbiCoder.encode(
-      ["bytes", "address"], 
-      [signature, ecdsaModule.address]
-    );
-
-    await expect(
-      forwardFlowModule.execTransaction(userSA.address, transaction, refundInfo, signatureWithModuleAddress)
-    ).to.emit(userSA, "ExecutionSuccess");
-    expect(await mockToken.balanceOf(charlie.address)).to.equal(charlieTokenBalanceBefore.add(tokenAmountToTransfer));
+      // DEPRECATED
+      // Only signatures over typed data hash are expected by this module
+      // because of the way it reconstructs hash to verify the signature
   }); 
+  */
 
   it("can send transactions and charge smart account for fees in native tokens", async function () {
     const { 


### PR DESCRIPTION
* Removed `eth_sign` flow handling in a default ECDSA Ownership Registry Module (v>30 check)
* Moved this to a [separate module](https://github.com/bcnmy/scw-contracts/blob/2023-06-14-ECDSA-Module-eth-flow-remove/contracts/smart-contract-wallet/modules/Exotic/EcdsaEthSignSupportOwnershipRegistryModule.sol). In case some dApp still uses this [outdated](https://support.metamask.io/hc/en-us/articles/14764161421467-What-is-eth-sign-and-why-is-it-a-risk-) flow, it can use this module for users' SAs
* Gas optimizations for ECDSA Ownership Module and Smart Contract Ownership Module
* Removed explicitly converting `userOpHash` to `EthSignedHash` for the [SmartContractOwnershipRegistryModule](https://github.com/bcnmy/scw-contracts/blob/2023-06-14-ECDSA-Module-eth-flow-remove/contracts/smart-contract-wallet/modules/SmartContractOwnershipRegistryModule.sol). See [comment](https://github.com/bcnmy/scw-contracts/blob/53926abed7b28b61ddadc6df55020267341df2f5/contracts/smart-contract-wallet/modules/SmartContractOwnershipRegistryModule.sol#L76-L80)