### PR TITLE
fix: YULException for Stack too Deep Error while compiling with viaIR: true

### DIFF
--- a/contracts/smart-account/base/ModuleManager.sol
+++ b/contracts/smart-account/base/ModuleManager.sol
@@ -238,27 +238,29 @@ abstract contract ModuleManager is
 
         for (uint256 i; i < to.length; ) {
             // Execute transaction without further confirmations.
-            success = execute(
+            success = _executeFromModule(
                 to[i],
                 value[i],
                 data[i],
-                operations[i],
-                gasleft()
+                operations[i]
             );
-            if (success) {
-                emit ModuleTransaction(
-                    msg.sender,
-                    to[i],
-                    value[i],
-                    data[i],
-                    operations[i]
-                );
-                emit ExecutionFromModuleSuccess(msg.sender);
-            } else emit ExecutionFromModuleFailure(msg.sender);
             unchecked {
                 ++i;
             }
         }
+    }
+
+    function _executeFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) internal returns (bool success) {
+        success = execute(to, value, data, operation, gasleft());
+        if (success) {
+            emit ModuleTransaction(msg.sender, to, value, data, operation);
+            emit ExecutionFromModuleSuccess(msg.sender);
+        } else emit ExecutionFromModuleFailure(msg.sender);
     }
 
     /**


### PR DESCRIPTION
This PR fixes the error in ModuleManager.sol while compiling with `viaIR` enabled.
```
YulException: Cannot swap Variable var_to_offset with Variable var_success: too deep in the stack by 3 slots in [ var_to_offset RET var_to_offset var_to_length var_data_offset var_value_offset var_value_length var_operations_offset var_operations_length var_data_length var_i var_i var_to_length var_data_offset var_value_offset var_value_length var_operations_offset var_operations_length var_data_length var_success ]
No memoryguard was present. Consider using memory-safe assembly only and annotating it via 'assembly ("memory-safe") { ... }'.


Error HH600: Compilation failed

For more info go to https://hardhat.org/HH600 or run Hardhat with --show-stack-traces
```