### PR TITLE
experimental: Linux Compatibility for Bundler Integration Tests

### DIFF
--- a/src/deploy/01_deploy_entrypoint.ts
+++ b/src/deploy/01_deploy_entrypoint.ts
@@ -11,6 +11,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [],
     log: true,
     deterministicDeployment: true, // Needed for bundler tests to ensure the entrypoint address does not change b/w tests
+    skipIfAlreadyDeployed: true,
     autoMine: true,
   });
 };

--- a/test/bundler-integration/environment/docker-compose.yml
+++ b/test/bundler-integration/environment/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
   bundler:
     ports: ["3000:3000"]
-    image: ankurdubeybiconomy/bundler:latest # Image based off accountabstraction/bundler:0.6.1 with fixes for debug_bundler_clearState
+    image: ankurdubeybiconomy/bundler:dev # Image based off accountabstraction/bundler:0.6.1 with fixes for debug_bundler_clearState
     command: --network http://geth-dev:8545 --entryPoint ${ENTRYPOINT} --show-stack-traces
     volumes:
       - ./workdir:/app/workdir:ro

--- a/test/bundler-integration/module/SessionKeyManager.Module.specs.ts
+++ b/test/bundler-integration/module/SessionKeyManager.Module.specs.ts
@@ -6,7 +6,7 @@ import {
   enableNewTreeForSmartAccountViaEcdsa,
 } from "../../utils/sessionKey";
 import { encodeTransfer } from "../../utils/testUtils";
-import { hexZeroPad, hexConcat } from "ethers/lib/utils";
+import { hexZeroPad, hexConcat, parseEther } from "ethers/lib/utils";
 import {
   getEntryPoint,
   getSmartAccountImplementation,
@@ -15,15 +15,18 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../utils/setupHelper";
 import { keccak256 } from "ethereumjs-util";
 import { MerkleTree } from "merkletreejs";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
+import { Wallet } from "ethers";
 
 describe("SessionKey: SessionKey Manager Module (with Bundler)", async () => {
-  let [deployer, smartAccountOwner, charlie, verifiedSigner, sessionKey] =
+  let [deployer, charlie, verifiedSigner, sessionKey] =
     [] as SignerWithAddress[];
+  let smartAccountOwner: Wallet;
 
   let environment: BundlerTestEnvironment;
 
@@ -37,8 +40,8 @@ describe("SessionKey: SessionKey Manager Module (with Bundler)", async () => {
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner, charlie, verifiedSigner, sessionKey] =
-      await ethers.getSigners();
+    [deployer, charlie, verifiedSigner, sessionKey] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -47,10 +50,7 @@ describe("SessionKey: SessionKey Manager Module (with Bundler)", async () => {
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/bundler-integration/module/SessionValidationModules/ERC20SessionValidation.Module.specs.ts
+++ b/test/bundler-integration/module/SessionValidationModules/ERC20SessionValidation.Module.specs.ts
@@ -15,21 +15,18 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../../utils/setupHelper";
-import { BigNumber } from "ethers";
+import { BigNumber, Wallet } from "ethers";
 import { UserOperation } from "../../../utils/userOperation";
 import { BundlerTestEnvironment } from "../../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { parseEther } from "ethers/lib/utils";
 
 describe("SessionKey: ERC20 Session Validation Module (with Bundler)", async () => {
-  let [
-    deployer,
-    smartAccountOwner,
-    alice,
-    charlie,
-    verifiedSigner,
-    sessionKey,
-  ] = [] as SignerWithAddress[];
+  let [deployer, alice, charlie, verifiedSigner, sessionKey] =
+    [] as SignerWithAddress[];
+  let smartAccountOwner: Wallet;
   const maxAmount = ethers.utils.parseEther("100");
 
   let environment: BundlerTestEnvironment;
@@ -44,8 +41,9 @@ describe("SessionKey: ERC20 Session Validation Module (with Bundler)", async () 
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner, alice, charlie, verifiedSigner, sessionKey] =
+    [deployer, alice, charlie, verifiedSigner, sessionKey] =
       await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -54,10 +52,7 @@ describe("SessionKey: ERC20 Session Validation Module (with Bundler)", async () 
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/bundler-integration/smart-account/SA.Basics.specs.ts
+++ b/test/bundler-integration/smart-account/SA.Basics.specs.ts
@@ -9,6 +9,7 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../utils/setupHelper";
 import {
   makeEcdsaModuleUserOp,
@@ -16,10 +17,12 @@ import {
 } from "../../utils/userOp";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { parseEther } from "ethers/lib/utils";
+import { Wallet } from "ethers";
 
 describe("Modular Smart Account Basics (with Bundler)", async () => {
   let deployer: SignerWithAddress,
-    smartAccountOwner: SignerWithAddress,
+    smartAccountOwner: Wallet,
     charlie: SignerWithAddress,
     verifiedSigner: SignerWithAddress;
   let environment: BundlerTestEnvironment;
@@ -34,8 +37,8 @@ describe("Modular Smart Account Basics (with Bundler)", async () => {
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner, charlie, verifiedSigner] =
-      await ethers.getSigners();
+    [deployer, charlie, verifiedSigner] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -44,10 +47,7 @@ describe("Modular Smart Account Basics (with Bundler)", async () => {
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/bundler-integration/smart-account/SA.Basics.specs.ts
+++ b/test/bundler-integration/smart-account/SA.Basics.specs.ts
@@ -162,7 +162,7 @@ describe("Modular Smart Account Basics (with Bundler)", async () => {
 
     const blockTimestamp = (await ethers.provider.getBlock("latest")).timestamp;
     const validUntil = blockTimestamp + 1000;
-    const validAfter = blockTimestamp;
+    const validAfter = blockTimestamp - 1000;
 
     const userOp = await makeEcdsaModuleUserOpWithPaymaster(
       "execute_ncC",

--- a/test/bundler-integration/smart-account/SA.Modules.specs.ts
+++ b/test/bundler-integration/smart-account/SA.Modules.specs.ts
@@ -8,14 +8,17 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../utils/setupHelper";
 import { makeEcdsaModuleUserOp } from "../../utils/userOp";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { Wallet } from "ethers";
+import { parseEther } from "ethers/lib/utils";
 
 describe("Modular Smart Account Modules (with Bundler)", async () => {
   let deployer: SignerWithAddress,
-    smartAccountOwner: SignerWithAddress,
+    smartAccountOwner: Wallet,
     alice: SignerWithAddress,
     bob: SignerWithAddress,
     charlie: SignerWithAddress,
@@ -33,8 +36,8 @@ describe("Modular Smart Account Modules (with Bundler)", async () => {
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner, alice, bob, charlie, verifiedSigner] =
-      await ethers.getSigners();
+    [deployer, alice, bob, charlie, verifiedSigner] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -43,10 +46,7 @@ describe("Modular Smart Account Modules (with Bundler)", async () => {
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/bundler-integration/smart-account/SA.Setup.specs.ts
+++ b/test/bundler-integration/smart-account/SA.Setup.specs.ts
@@ -9,14 +9,17 @@ import {
   getSmartAccountWithModule,
   getVerifyingPaymaster,
   deployContract,
+  getRandomFundedWallet,
 } from "../../utils/setupHelper";
 import { makeEcdsaModuleUserOp } from "../../utils/userOp";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { Wallet } from "ethers";
+import { parseEther } from "ethers/lib/utils";
 
 describe("Smart Account Setup (with Bundler)", async () => {
   let deployer: SignerWithAddress,
-    smartAccountOwner: SignerWithAddress,
+    smartAccountOwner: Wallet,
     verifiedSigner: SignerWithAddress;
 
   let environment: BundlerTestEnvironment;
@@ -31,7 +34,8 @@ describe("Smart Account Setup (with Bundler)", async () => {
   });
 
   beforeEach(async () => {
-    [deployer, smartAccountOwner, verifiedSigner] = await ethers.getSigners();
+    [deployer, verifiedSigner] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -40,10 +44,7 @@ describe("Smart Account Setup (with Bundler)", async () => {
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/bundler-integration/smart-account/SA.UserOps.specs.ts
+++ b/test/bundler-integration/smart-account/SA.UserOps.specs.ts
@@ -9,14 +9,17 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../utils/setupHelper";
 import { makeEcdsaModuleUserOp } from "../../utils/userOp";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { Wallet } from "ethers";
+import { parseEther } from "ethers/lib/utils";
 
 describe("UserOps (with Bundler)", async () => {
   let deployer: SignerWithAddress,
-    smartAccountOwner: SignerWithAddress,
+    smartAccountOwner: Wallet,
     charlie: SignerWithAddress,
     verifiedSigner: SignerWithAddress;
 
@@ -32,8 +35,8 @@ describe("UserOps (with Bundler)", async () => {
   });
 
   beforeEach(async () => {
-    [deployer, smartAccountOwner, charlie, verifiedSigner] =
-      await ethers.getSigners();
+    [deployer, charlie, verifiedSigner] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -42,7 +45,6 @@ describe("UserOps (with Bundler)", async () => {
       this.skip();
     }
 
-    await environment.revert(environment.defaultSnapshot!);
     await environment.resetBundler();
   });
 

--- a/test/bundler-integration/upgrades/v1-to-v2/v1-to-v2-upgrade.specs.ts
+++ b/test/bundler-integration/upgrades/v1-to-v2/v1-to-v2-upgrade.specs.ts
@@ -9,14 +9,17 @@ import {
   getEcdsaOwnershipRegistryModule,
   getSmartAccountWithModule,
   getVerifyingPaymaster,
+  getRandomFundedWallet,
 } from "../../../utils/setupHelper";
 import { fillAndSign, makeEcdsaModuleUserOp } from "../../../utils/userOp";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BundlerTestEnvironment } from "../../environment/bundlerEnvironment";
+import { Wallet } from "ethers";
+import { parseEther } from "ethers/lib/utils";
 
 describe("Upgrade v1 to Modular (v2) (ex. Ownerless) (with Bundler)", async () => {
-  let [deployer, smartAccountOwner, charlie, verifiedSigner] =
-    [] as SignerWithAddress[];
+  let [deployer, charlie, verifiedSigner] = [] as SignerWithAddress[];
+  let smartAccountOwner: Wallet;
 
   let environment: BundlerTestEnvironment;
 
@@ -30,8 +33,8 @@ describe("Upgrade v1 to Modular (v2) (ex. Ownerless) (with Bundler)", async () =
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner, charlie, verifiedSigner] =
-      await ethers.getSigners();
+    [deployer, charlie, verifiedSigner] = await ethers.getSigners();
+    smartAccountOwner = await getRandomFundedWallet(deployer, parseEther("1"));
   });
 
   afterEach(async function () {
@@ -40,10 +43,7 @@ describe("Upgrade v1 to Modular (v2) (ex. Ownerless) (with Bundler)", async () =
       this.skip();
     }
 
-    await Promise.all([
-      environment.revert(environment.defaultSnapshot!),
-      environment.resetBundler(),
-    ]);
+    await environment.resetBundler();
   });
 
   const setupTests = deployments.createFixture(

--- a/test/utils/setupHelper.ts
+++ b/test/utils/setupHelper.ts
@@ -1,12 +1,11 @@
 import hre, { deployments, ethers } from "hardhat";
-import { Wallet, Contract, BytesLike, Signer } from "ethers";
+import { Wallet, Contract, BytesLike, Signer, BigNumberish } from "ethers";
 import { EntryPoint__factory } from "../../typechain";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 const solc = require("solc");
 
 export const getEntryPoint = async () => {
   const EntryPointDeployment = await deployments.get("EntryPoint");
-  const EntryPoint = await hre.ethers.getContractFactory("EntryPoint");
   return EntryPoint__factory.connect(
     EntryPointDeployment.address,
     ethers.provider.getSigner()
@@ -24,7 +23,9 @@ export const getSmartAccountFactory = async () => {
   const SmartAccountFactory = await hre.ethers.getContractFactory(
     "SmartAccountFactory"
   );
-  const smartAccountFactory = SmartAccountFactory.attach(SAFactoryDeployment.address);
+  const smartAccountFactory = SmartAccountFactory.attach(
+    SAFactoryDeployment.address
+  );
   return smartAccountFactory;
 };
 
@@ -33,11 +34,15 @@ export const getStakedSmartAccountFactory = async () => {
   const SmartAccountFactory = await hre.ethers.getContractFactory(
     "SmartAccountFactory"
   );
-  const smartAccountFactory = SmartAccountFactory.attach(SAFactoryDeployment.address);
+  const smartAccountFactory = SmartAccountFactory.attach(
+    SAFactoryDeployment.address
+  );
   const entryPoint = await getEntryPoint();
   const unstakeDelay = 600;
   const stakeValue = ethers.utils.parseEther("10");
-  await smartAccountFactory.addStake(entryPoint.address, unstakeDelay, {value: stakeValue});
+  await smartAccountFactory.addStake(entryPoint.address, unstakeDelay, {
+    value: stakeValue,
+  });
   return smartAccountFactory;
 };
 
@@ -170,4 +175,16 @@ export const deployContract = async (
   });
   const receipt = await transaction.wait();
   return new Contract(receipt.contractAddress, output.interface, deployer);
+};
+
+export const getRandomFundedWallet = async (
+  fundingAccount: SignerWithAddress,
+  amount: BigNumberish
+): Promise<Wallet> => {
+  const wallet = Wallet.createRandom();
+  await fundingAccount.sendTransaction({
+    to: wallet.address,
+    value: amount,
+  });
+  return wallet;
 };


### PR DESCRIPTION
In the Linux build of geth's docker image, the implementation of `debug_setHead` appears to be broken - the node immediately crashes after calling this RPC method. This is not the case with their M1 builds, where the RPC works fine.

We use this RPC method to reset the state of the blockchain after each test case is run, to ensure that each test is running under the same conditions. This PR removes the usage of this RPC, and introduces "hacks" to account for the fact that the blockchain state between each test is shared.
These hacks include:
1. Randomizing the `smartAccountOwner` address between each test run to ensure that the smart account is deployed to a new address for each test, otherwise the test fails with `CREATE2 failed`
2. Turning on `skipIfAlreadyDeployed` in the deployment script for `Entrypoint`.

In general, this results in a degraded testing experience and results in a significant increase in complexity while writing tests. I have created an issue on geth to hopefully get this fixed on their end [here](https://github.com/ethereum/go-ethereum/issues/27990).