### PR TITLE
fix userOp encode bug

### DIFF
--- a/contracts/smart-account/modules/PasskeyRegistryModule.sol
+++ b/contracts/smart-account/modules/PasskeyRegistryModule.sol
@@ -116,7 +116,11 @@ contract PasskeyRegistryModule is BaseAuthorizationModule {
         UserOperation calldata userOp,
         bytes32 userOpHash
     ) internal view virtual returns (uint256 sigValidationResult) {
-        if (_verifySignature(userOpHash, userOp.signature)) {
+        (bytes memory moduleSignature,) = abi.decode(
+            userOp.signature,
+            (bytes, address)
+        );
+        if (_verifySignature(userOpHash, moduleSignature)) {
             return 0;
         }
         return SIG_VALIDATION_FAILED;


### PR DESCRIPTION
# Summary

The signature of UserOp should be decoded twice in order to be decoded into the raw signature. 


## Change Type

- [x] Bug Fix
- [ ] Bug Fix
- [ ] Refactor
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [ ] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [x] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

