### PR TITLE
Multi Owned ECDSA Validation Module

### DIFF
--- a/contracts/smart-account/interfaces/modules/IMultiOwnedECDSAModule.sol
+++ b/contracts/smart-account/interfaces/modules/IMultiOwnedECDSAModule.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+/**
+ * @title ECDSA ownership Authorization module for Biconomy Smart Accounts.
+ * @dev Compatible with Biconomy Modular Interface v 0.1
+ *         - It allows to validate user operations signed by EOA private key.
+ *         - EIP-1271 compatible (ensures Smart Account can validate signed messages).
+ *         - One owner per Smart Account.
+ *         - Does not support outdated eth_sign flow for cheaper validations
+ *         (see https://support.metamask.io/hc/en-us/articles/14764161421467-What-is-eth-sign-and-why-is-it-a-risk-)
+ * !!!!!!! Only EOA owners supported, no Smart Account Owners
+ *         For Smart Contract Owners check SmartContractOwnership module instead
+ * @author Fil Makarov - <filipp.makarov@biconomy.io>
+ */
+interface IMultiOwnedECDSAModule {
+    event OwnershipTransferred(
+        address indexed smartAccount,
+        address indexed oldOwner,
+        address indexed newOwner
+    );
+
+    error AlreadyInitedForSmartAccount(address smartAccount);
+    error WrongSignatureLength();
+    error NotEOA(address account);
+    error ZeroAddressNotAllowedAsOwner();
+    error OwnerAlreadyUsedForSmartAccount(address owner, address smartAccount);
+
+    /**
+     * @dev Initializes the module for a Smart Account.
+     * Should be used at a time of first enabling the module for a Smart Account.
+     * @param eoaOwners The owner of the Smart Account. Should be EOA!
+     */
+    function initForSmartAccount(address[] calldata eoaOwners) external returns (address);
+
+    /**
+     * @dev Sets/changes an for a Smart Account.
+     * Should be called by Smart Account itself.
+     * @param owner The current owner of the Smart Account to be replaced.
+     * @param newOwner The new owner of the Smart Account.
+     */
+    function transferOwnership(address owner, address newOwner) external;
+
+    /**
+     * @dev Adds owner for Smart Account.
+     * should be called by Smart Account.
+     * @param owner The owner of the Smart Account.
+     */
+    function addOwner(address owner) external;
+
+    /**
+     * @dev Renounces ownership from owner
+     * should be called by Smart Account.
+     * @param owner The owner to be removed
+     */
+    function removeOwner(address owner) external;
+
+    /**
+     * @dev Returns the if the address provided is one of owners of the Smart Account.
+     * @param smartAccount Smart Account address.
+     * @param eoaAddress The address to check for ownership
+     */
+    function isOwner(
+        address smartAccount,
+        address eoaAddress
+    ) external view returns (bool);
+
+    /**
+     * @dev Validates a signature for a message signed by address.
+     * @dev Also try dataHash.toEthSignedMessageHash()
+     * @param dataHash hash of the data
+     * @param moduleSignature Signature to be validated.
+     * @param smartAccount expected signer Smart Account address.
+     * @return EIP1271_MAGIC_VALUE if signature is valid, 0xffffffff otherwise.
+     */
+    function isValidSignatureForAddress(
+        bytes32 dataHash,
+        bytes memory moduleSignature,
+        address smartAccount
+    ) external view returns (bytes4);
+}

--- a/contracts/smart-account/interfaces/modules/IMultiOwnedECDSAModule.sol
+++ b/contracts/smart-account/interfaces/modules/IMultiOwnedECDSAModule.sol
@@ -31,7 +31,9 @@ interface IMultiOwnedECDSAModule {
      * Should be used at a time of first enabling the module for a Smart Account.
      * @param eoaOwners The owner of the Smart Account. Should be EOA!
      */
-    function initForSmartAccount(address[] calldata eoaOwners) external returns (address);
+    function initForSmartAccount(
+        address[] calldata eoaOwners
+    ) external returns (address);
 
     /**
      * @dev Sets/changes an for a Smart Account.

--- a/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
+++ b/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
@@ -34,21 +34,24 @@ contract MultiOwnedECDSAModule is
     string public constant VERSION = "0.2.0";
 
     // owner => smartAccount => isOwner
-    mapping(address => mapping (address => bool)) internal _smartAccountOwners;
-    mapping (address => uint256) internal numberOfOwners;
+    mapping(address => mapping(address => bool)) internal _smartAccountOwners;
+    mapping(address => uint256) internal numberOfOwners;
 
     /// @inheritdoc IMultiOwnedECDSAModule
     function initForSmartAccount(
         address[] calldata eoaOwners
     ) external returns (address) {
-
         if (numberOfOwners[msg.sender] != 0) {
             revert AlreadyInitedForSmartAccount(msg.sender);
         }
-        for(uint256 i; i < eoaOwners.length; ) {
-            if (eoaOwners[i] == address(0)) revert ZeroAddressNotAllowedAsOwner();
+        for (uint256 i; i < eoaOwners.length; ) {
+            if (eoaOwners[i] == address(0))
+                revert ZeroAddressNotAllowedAsOwner();
             if (_smartAccountOwners[eoaOwners[i]][msg.sender])
-                revert OwnerAlreadyUsedForSmartAccount(eoaOwners[i], msg.sender);
+                revert OwnerAlreadyUsedForSmartAccount(
+                    eoaOwners[i],
+                    msg.sender
+                );
 
             _smartAccountOwners[eoaOwners[i]][msg.sender] = true;
             numberOfOwners[msg.sender]++;
@@ -60,11 +63,15 @@ contract MultiOwnedECDSAModule is
     }
 
     /// @inheritdoc IMultiOwnedECDSAModule
-    function transferOwnership(address owner, address newOwner) external override {
+    function transferOwnership(
+        address owner,
+        address newOwner
+    ) external override {
         if (_isSmartContract(newOwner)) revert NotEOA(owner);
         if (newOwner == address(0)) revert ZeroAddressNotAllowedAsOwner();
         if (owner == address(0)) revert ZeroAddressNotAllowedAsOwner();
-        if (owner == newOwner) revert OwnerAlreadyUsedForSmartAccount(newOwner, msg.sender);
+        if (owner == newOwner)
+            revert OwnerAlreadyUsedForSmartAccount(newOwner, msg.sender);
         _transferOwnership(msg.sender, owner, newOwner);
     }
 
@@ -83,7 +90,6 @@ contract MultiOwnedECDSAModule is
     function removeOwner(address owner) external override {
         _transferOwnership(msg.sender, owner, address(0));
         --numberOfOwners[msg.sender];
-
     }
 
     /// @inheritdoc IMultiOwnedECDSAModule
@@ -171,11 +177,17 @@ contract MultiOwnedECDSAModule is
         address recovered = (dataHash.toEthSignedMessageHash()).recover(
             signature
         );
-        if (recovered != address(0) && _smartAccountOwners[recovered][smartAccount]) {
+        if (
+            recovered != address(0) &&
+            _smartAccountOwners[recovered][smartAccount]
+        ) {
             return true;
         }
         recovered = dataHash.recover(signature);
-        if (recovered != address(0) && _smartAccountOwners[recovered][smartAccount]) {
+        if (
+            recovered != address(0) &&
+            _smartAccountOwners[recovered][smartAccount]
+        ) {
             return true;
         }
         return false;

--- a/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
+++ b/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+/* solhint-disable no-unused-import */
+
+import {BaseAuthorizationModule} from "./BaseAuthorizationModule.sol";
+import {EIP1271_MAGIC_VALUE} from "contracts/smart-account/interfaces/ISignatureValidator.sol";
+import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IMultiOwnedECDSAModule} from "../interfaces/modules/IMultiOwnedECDSAModule.sol";
+import {IAuthorizationModule} from "../interfaces/IAuthorizationModule.sol";
+import {ISignatureValidator} from "../interfaces/ISignatureValidator.sol";
+
+/**
+ * @title ECDSA ownership Authorization module for Biconomy Smart Accounts.
+ * @dev Compatible with Biconomy Modular Interface v 0.1
+ *         - It allows to validate user operations signed by EOA private key.
+ *         - EIP-1271 compatible (ensures Smart Account can validate signed messages).
+ *         - One owner per Smart Account.
+ *         - Does not support outdated eth_sign flow for cheaper validations
+ *         (see https://support.metamask.io/hc/en-us/articles/14764161421467-What-is-eth-sign-and-why-is-it-a-risk-)
+ * !!!!!!! Only EOA owners supported, no Smart Account Owners
+ *         For Smart Contract Owners check SmartContractOwnership module instead
+ * @author Fil Makarov - <filipp.makarov@biconomy.io>
+ */
+
+contract MultiOwnedECDSAModule is
+    BaseAuthorizationModule,
+    IMultiOwnedECDSAModule
+{
+    using ECDSA for bytes32;
+
+    string public constant NAME = "ECDSA Ownership Registry Module";
+    string public constant VERSION = "0.2.0";
+
+    // owner => smartAccount => isOwner
+    mapping(address => mapping (address => bool)) internal _smartAccountOwners;
+    mapping (address => uint256) internal numberOfOwners;
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function initForSmartAccount(
+        address[] calldata eoaOwners
+    ) external returns (address) {
+
+        if (numberOfOwners[msg.sender] != 0) {
+            revert AlreadyInitedForSmartAccount(msg.sender);
+        }
+        for(uint256 i; i < eoaOwners.length; ) {
+            if (eoaOwners[i] == address(0)) revert ZeroAddressNotAllowedAsOwner();
+            if (_smartAccountOwners[eoaOwners[i]][msg.sender])
+                revert OwnerAlreadyUsedForSmartAccount(eoaOwners[i], msg.sender);
+
+            _smartAccountOwners[eoaOwners[i]][msg.sender] = true;
+            numberOfOwners[msg.sender]++;
+            unchecked {
+                ++i;
+            }
+        }
+        return address(this);
+    }
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function transferOwnership(address owner, address newOwner) external override {
+        if (_isSmartContract(newOwner)) revert NotEOA(owner);
+        if (newOwner == address(0)) revert ZeroAddressNotAllowedAsOwner();
+        if (owner == address(0)) revert ZeroAddressNotAllowedAsOwner();
+        if (owner == newOwner) revert OwnerAlreadyUsedForSmartAccount(newOwner, msg.sender);
+        _transferOwnership(msg.sender, owner, newOwner);
+    }
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function addOwner(address owner) external override {
+        if (_isSmartContract(owner)) revert NotEOA(owner);
+        if (owner == address(0)) revert ZeroAddressNotAllowedAsOwner();
+        if (_smartAccountOwners[owner][msg.sender])
+            revert OwnerAlreadyUsedForSmartAccount(owner, msg.sender);
+
+        _smartAccountOwners[owner][msg.sender] = true;
+        numberOfOwners[msg.sender]++;
+    }
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function removeOwner(address owner) external override {
+        _transferOwnership(msg.sender, owner, address(0));
+        --numberOfOwners[msg.sender];
+
+    }
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function isOwner(
+        address smartAccount,
+        address eoaAddress
+    ) external view override returns (bool) {
+        return _smartAccountOwners[eoaAddress][smartAccount];
+    }
+
+    /// @inheritdoc IAuthorizationModule
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash
+    ) external view virtual override returns (uint256) {
+        (bytes memory cleanEcdsaSignature, ) = abi.decode(
+            userOp.signature,
+            (bytes, address)
+        );
+        if (_verifySignature(userOpHash, cleanEcdsaSignature, userOp.sender)) {
+            return VALIDATION_SUCCESS;
+        }
+        return SIG_VALIDATION_FAILED;
+    }
+
+    /**
+     * @inheritdoc ISignatureValidator
+     * @dev Validates a signature for a message.
+     * To be called from a Smart Account.
+     * @param dataHash Exact hash of the data that was signed.
+     * @param moduleSignature Signature to be validated.
+     * @return EIP1271_MAGIC_VALUE if signature is valid, 0xffffffff otherwise.
+     */
+    function isValidSignature(
+        bytes32 dataHash,
+        bytes memory moduleSignature
+    ) public view virtual override returns (bytes4) {
+        return
+            isValidSignatureForAddress(dataHash, moduleSignature, msg.sender);
+    }
+
+    /// @inheritdoc IMultiOwnedECDSAModule
+    function isValidSignatureForAddress(
+        bytes32 dataHash,
+        bytes memory moduleSignature,
+        address smartAccount
+    ) public view virtual override returns (bytes4) {
+        if (_verifySignature(dataHash, moduleSignature, smartAccount)) {
+            return EIP1271_MAGIC_VALUE;
+        }
+        return bytes4(0xffffffff);
+    }
+
+    /**
+     * @dev Transfers ownership for smartAccount and emits an event
+     * @param newOwner Smart Account address.
+     */
+    function _transferOwnership(
+        address smartAccount,
+        address owner,
+        address newOwner
+    ) internal {
+        _smartAccountOwners[owner][smartAccount] = false;
+        _smartAccountOwners[newOwner][smartAccount] = true;
+        emit OwnershipTransferred(smartAccount, owner, newOwner);
+    }
+
+    /**
+     * @dev Validates a signature for a message.
+     * @dev Check if signature was made over dataHash.toEthSignedMessageHash() or just dataHash
+     * The former is for personal_sign, the latter for the typed_data sign
+     * Only EOA owners supported, no Smart Account Owners
+     * For Smart Contract Owners check SmartContractOwnership Module instead
+     * @param dataHash Hash of the data to be validated.
+     * @param signature Signature to be validated.
+     * @param smartAccount expected signer Smart Account address.
+     * @return true if signature is valid, false otherwise.
+     */
+    function _verifySignature(
+        bytes32 dataHash,
+        bytes memory signature,
+        address smartAccount
+    ) internal view returns (bool) {
+        if (signature.length < 65) revert WrongSignatureLength();
+        address recovered = (dataHash.toEthSignedMessageHash()).recover(
+            signature
+        );
+        if (recovered != address(0) && _smartAccountOwners[recovered][smartAccount]) {
+            return true;
+        }
+        recovered = dataHash.recover(signature);
+        if (recovered != address(0) && _smartAccountOwners[recovered][smartAccount]) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @dev Checks if the address provided is a smart contract.
+     * @param account Address to be checked.
+     */
+    function _isSmartContract(address account) internal view returns (bool) {
+        uint256 size;
+        assembly {
+            size := extcodesize(account)
+        }
+        return size > 0;
+    }
+}

--- a/test/bundler-integration/module/MultiOwnedECDSA.Module.specs.ts
+++ b/test/bundler-integration/module/MultiOwnedECDSA.Module.specs.ts
@@ -14,7 +14,13 @@ import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 describe("MultiOwned ECDSA Module (with Bundler):", async () => {
-  let [deployer, smartAccountOwner1, smartAccountOwner2, smartAccountOwner3, eve] = [] as SignerWithAddress[];
+  let [
+    deployer,
+    smartAccountOwner1,
+    smartAccountOwner2,
+    smartAccountOwner3,
+    eve,
+  ] = [] as SignerWithAddress[];
   const smartAccountDeploymentIndex = 0;
   const SIG_VALIDATION_SUCCESS = 0;
   let environment: BundlerTestEnvironment;
@@ -29,7 +35,13 @@ describe("MultiOwned ECDSA Module (with Bundler):", async () => {
   });
 
   beforeEach(async function () {
-    [deployer, smartAccountOwner1, smartAccountOwner2, smartAccountOwner3, eve] = await ethers.getSigners();
+    [
+      deployer,
+      smartAccountOwner1,
+      smartAccountOwner2,
+      smartAccountOwner3,
+      eve,
+    ] = await ethers.getSigners();
   });
 
   afterEach(async function () {
@@ -55,9 +67,16 @@ describe("MultiOwned ECDSA Module (with Bundler):", async () => {
     const mockToken = await getMockToken();
 
     const ecdsaOwnershipSetupData =
-      multiOwnedECDSAModule.interface.encodeFunctionData("initForSmartAccount", [
-        [smartAccountOwner1.address, smartAccountOwner2.address, smartAccountOwner3.address],
-      ]);
+      multiOwnedECDSAModule.interface.encodeFunctionData(
+        "initForSmartAccount",
+        [
+          [
+            smartAccountOwner1.address,
+            smartAccountOwner2.address,
+            smartAccountOwner3.address,
+          ],
+        ]
+      );
 
     const deploymentData = saFactory.interface.encodeFunctionData(
       "deployCounterFactualAccount",
@@ -141,7 +160,7 @@ describe("MultiOwned ECDSA Module (with Bundler):", async () => {
         "execute_ncC",
         [multiOwnedECDSAModule.address, 0, txnData1],
         userSA.address,
-        smartAccountOwner1, //can be signed by any owner
+        smartAccountOwner1, // can be signed by any owner
         entryPoint,
         multiOwnedECDSAModule.address,
         {
@@ -150,76 +169,81 @@ describe("MultiOwned ECDSA Module (with Bundler):", async () => {
       );
 
       await environment.sendUserOperation(userOp, entryPoint.address);
-      expect(await multiOwnedECDSAModule.isOwner(userSA.address, eve.address)).to.be.true;
+      expect(
+        await multiOwnedECDSAModule.isOwner(userSA.address, eve.address)
+      ).to.equal(true);
     });
   });
 
   describe("removeOwner():", async () => {
     it("Should be able to renounce ownership and the new owner should be address(0)", async () => {
-        const { multiOwnedECDSAModule, entryPoint, userSA } = await setupTests();
-        const txnData1 = multiOwnedECDSAModule.interface.encodeFunctionData(
-          "removeOwner",
-          [smartAccountOwner2.address]
-        );
-        const userOp = await makeEcdsaModuleUserOp(
-          "execute_ncC",
-          [multiOwnedECDSAModule.address, 0, txnData1],
-          userSA.address,
-          smartAccountOwner3, //any owner can sign
-          entryPoint,
-          multiOwnedECDSAModule.address,
-          {
-            preVerificationGas: 50000,
-          }
-        );
+      const { multiOwnedECDSAModule, entryPoint, userSA } = await setupTests();
+      const txnData1 = multiOwnedECDSAModule.interface.encodeFunctionData(
+        "removeOwner",
+        [smartAccountOwner2.address]
+      );
+      const userOp = await makeEcdsaModuleUserOp(
+        "execute_ncC",
+        [multiOwnedECDSAModule.address, 0, txnData1],
+        userSA.address,
+        smartAccountOwner3, // any owner can sign
+        entryPoint,
+        multiOwnedECDSAModule.address,
+        {
+          preVerificationGas: 50000,
+        }
+      );
 
-        await environment.sendUserOperation(userOp, entryPoint.address);
-        expect(
-          await multiOwnedECDSAModule.isOwner(userSA.address, smartAccountOwner2.address)
-        ).to.be.false;
+      await environment.sendUserOperation(userOp, entryPoint.address);
+      expect(
+        await multiOwnedECDSAModule.isOwner(
+          userSA.address,
+          smartAccountOwner2.address
+        )
+      ).to.equal(false);
     });
   });
 
   describe("validateUserOp(): ", async () => {
     it("Returns SIG_VALIDATION_SUCCESS for a valid UserOp and valid userOpHash and allows to handle userOp", async () => {
-        const { multiOwnedECDSAModule, entryPoint, userSA, mockToken } =
-          await setupTests();
-        const userSABalanceBefore = await mockToken.balanceOf(userSA.address);
-        const eveBalanceBefore = await mockToken.balanceOf(eve.address);
-        const tokenAmountToTransfer = ethers.utils.parseEther("3.5672");
+      const { multiOwnedECDSAModule, entryPoint, userSA, mockToken } =
+        await setupTests();
+      const userSABalanceBefore = await mockToken.balanceOf(userSA.address);
+      const eveBalanceBefore = await mockToken.balanceOf(eve.address);
+      const tokenAmountToTransfer = ethers.utils.parseEther("3.5672");
 
-        const txnData = mockToken.interface.encodeFunctionData("transfer", [
-          eve.address,
-          tokenAmountToTransfer.toString(),
-        ]);
-        const userOp = await makeEcdsaModuleUserOp(
-          "execute_ncC",
-          [mockToken.address, 0, txnData],
-          userSA.address,
-          smartAccountOwner2, //any owner can sign
-          entryPoint,
-          multiOwnedECDSAModule.address,
-          {
-            preVerificationGas: 50000,
-          }
-        );
-        // Construct userOpHash
-        const provider = entryPoint?.provider;
-        const chainId = await provider!.getNetwork().then((net) => net.chainId);
-        const userOpHash = getUserOpHash(userOp, entryPoint.address, chainId);
+      const txnData = mockToken.interface.encodeFunctionData("transfer", [
+        eve.address,
+        tokenAmountToTransfer.toString(),
+      ]);
+      const userOp = await makeEcdsaModuleUserOp(
+        "execute_ncC",
+        [mockToken.address, 0, txnData],
+        userSA.address,
+        smartAccountOwner2, // any owner can sign
+        entryPoint,
+        multiOwnedECDSAModule.address,
+        {
+          preVerificationGas: 50000,
+        }
+      );
+      // Construct userOpHash
+      const provider = entryPoint?.provider;
+      const chainId = await provider!.getNetwork().then((net) => net.chainId);
+      const userOpHash = getUserOpHash(userOp, entryPoint.address, chainId);
 
-        const res = await multiOwnedECDSAModule.validateUserOp(
-          userOp,
-          userOpHash
-        );
-        expect(res).to.be.equal(SIG_VALIDATION_SUCCESS);
-        await environment.sendUserOperation(userOp, entryPoint.address);
-        expect(await mockToken.balanceOf(eve.address)).to.equal(
-          eveBalanceBefore.add(tokenAmountToTransfer)
-        );
-        expect(await mockToken.balanceOf(userSA.address)).to.equal(
-          userSABalanceBefore.sub(tokenAmountToTransfer)
-        );
+      const res = await multiOwnedECDSAModule.validateUserOp(
+        userOp,
+        userOpHash
+      );
+      expect(res).to.be.equal(SIG_VALIDATION_SUCCESS);
+      await environment.sendUserOperation(userOp, entryPoint.address);
+      expect(await mockToken.balanceOf(eve.address)).to.equal(
+        eveBalanceBefore.add(tokenAmountToTransfer)
+      );
+      expect(await mockToken.balanceOf(userSA.address)).to.equal(
+        userSABalanceBefore.sub(tokenAmountToTransfer)
+      );
     });
   });
 });

--- a/test/bundler-integration/module/MultiOwnedECDSA.Module.specs.ts
+++ b/test/bundler-integration/module/MultiOwnedECDSA.Module.specs.ts
@@ -1,0 +1,225 @@
+import { expect } from "chai";
+import { ethers, deployments } from "hardhat";
+import {
+  makeEcdsaModuleUserOp,
+  getUserOpHash,
+  fillAndSign,
+} from "../../utils/userOp";
+import {
+  getEntryPoint,
+  getMockToken,
+  getStakedSmartAccountFactory,
+} from "../../utils/setupHelper";
+import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+describe("MultiOwned ECDSA Module (with Bundler):", async () => {
+  let [deployer, smartAccountOwner1, smartAccountOwner2, smartAccountOwner3, eve] = [] as SignerWithAddress[];
+  const smartAccountDeploymentIndex = 0;
+  const SIG_VALIDATION_SUCCESS = 0;
+  let environment: BundlerTestEnvironment;
+
+  before(async function () {
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    if (chainId !== BundlerTestEnvironment.BUNDLER_ENVIRONMENT_CHAIN_ID) {
+      this.skip();
+    }
+
+    environment = await BundlerTestEnvironment.getDefaultInstance();
+  });
+
+  beforeEach(async function () {
+    [deployer, smartAccountOwner1, smartAccountOwner2, smartAccountOwner3, eve] = await ethers.getSigners();
+  });
+
+  afterEach(async function () {
+    const chainId = (await ethers.provider.getNetwork()).chainId;
+    if (chainId !== BundlerTestEnvironment.BUNDLER_ENVIRONMENT_CHAIN_ID) {
+      this.skip();
+    }
+
+    await Promise.all([
+      environment.revert(environment.defaultSnapshot!),
+      environment.resetBundler(),
+    ]);
+  });
+
+  const setupTests = deployments.createFixture(async ({ deployments }) => {
+    await deployments.fixture();
+
+    const entryPoint = await getEntryPoint();
+    const saFactory = await getStakedSmartAccountFactory();
+    const multiOwnedECDSAModule = await (
+      await ethers.getContractFactory("MultiOwnedECDSAModule")
+    ).deploy();
+    const mockToken = await getMockToken();
+
+    const ecdsaOwnershipSetupData =
+      multiOwnedECDSAModule.interface.encodeFunctionData("initForSmartAccount", [
+        [smartAccountOwner1.address, smartAccountOwner2.address, smartAccountOwner3.address],
+      ]);
+
+    const deploymentData = saFactory.interface.encodeFunctionData(
+      "deployCounterFactualAccount",
+      [
+        multiOwnedECDSAModule.address,
+        ecdsaOwnershipSetupData,
+        smartAccountDeploymentIndex,
+      ]
+    );
+
+    const expectedSmartAccountAddress =
+      await saFactory.getAddressForCounterFactualAccount(
+        multiOwnedECDSAModule.address,
+        ecdsaOwnershipSetupData,
+        smartAccountDeploymentIndex
+      );
+
+    const tokensToMint = ethers.utils.parseEther("100");
+    await mockToken.mint(expectedSmartAccountAddress, tokensToMint.toString());
+    await mockToken.mint(eve.address, tokensToMint.toString());
+
+    await deployer.sendTransaction({
+      to: expectedSmartAccountAddress,
+      value: ethers.utils.parseEther("60"),
+    });
+
+    await deployer.sendTransaction({
+      to: smartAccountOwner1.address,
+      value: ethers.utils.parseEther("60"),
+    });
+
+    // deployment userOp
+    const deploymentUserOp = await fillAndSign(
+      {
+        sender: expectedSmartAccountAddress,
+        callGasLimit: 1_000_000,
+        initCode: ethers.utils.hexConcat([saFactory.address, deploymentData]),
+        callData: "0x",
+        preVerificationGas: 50000,
+      },
+      smartAccountOwner1,
+      entryPoint,
+      "nonce"
+    );
+
+    const signatureWithModuleAddress = ethers.utils.defaultAbiCoder.encode(
+      ["bytes", "address"],
+      [deploymentUserOp.signature, multiOwnedECDSAModule.address]
+    );
+
+    deploymentUserOp.signature = signatureWithModuleAddress;
+
+    await environment.sendUserOperation(deploymentUserOp, entryPoint.address);
+
+    const userSA = await ethers.getContractAt(
+      "SmartAccount",
+      expectedSmartAccountAddress
+    );
+
+    return {
+      entryPoint: entryPoint,
+      saFactory: saFactory,
+      multiOwnedECDSAModule: multiOwnedECDSAModule,
+      ecdsaOwnershipSetupData: ecdsaOwnershipSetupData,
+      userSA: userSA,
+      mockToken: mockToken,
+    };
+  });
+
+  describe("transferOwnership: ", async () => {
+    it("Call transferOwnership from userSA and it successfully changes owner ", async () => {
+      const { multiOwnedECDSAModule, entryPoint, userSA } = await setupTests();
+      // console.log(await userSA.getImplementation());
+
+      // Calldata to set Eve as owner
+      const txnData1 = multiOwnedECDSAModule.interface.encodeFunctionData(
+        "transferOwnership",
+        [smartAccountOwner2.address, eve.address]
+      );
+      const userOp = await makeEcdsaModuleUserOp(
+        "execute_ncC",
+        [multiOwnedECDSAModule.address, 0, txnData1],
+        userSA.address,
+        smartAccountOwner1, //can be signed by any owner
+        entryPoint,
+        multiOwnedECDSAModule.address,
+        {
+          preVerificationGas: 50000,
+        }
+      );
+
+      await environment.sendUserOperation(userOp, entryPoint.address);
+      expect(await multiOwnedECDSAModule.isOwner(userSA.address, eve.address)).to.be.true;
+    });
+  });
+
+  describe("removeOwner():", async () => {
+    it("Should be able to renounce ownership and the new owner should be address(0)", async () => {
+        const { multiOwnedECDSAModule, entryPoint, userSA } = await setupTests();
+        const txnData1 = multiOwnedECDSAModule.interface.encodeFunctionData(
+          "removeOwner",
+          [smartAccountOwner2.address]
+        );
+        const userOp = await makeEcdsaModuleUserOp(
+          "execute_ncC",
+          [multiOwnedECDSAModule.address, 0, txnData1],
+          userSA.address,
+          smartAccountOwner3, //any owner can sign
+          entryPoint,
+          multiOwnedECDSAModule.address,
+          {
+            preVerificationGas: 50000,
+          }
+        );
+
+        await environment.sendUserOperation(userOp, entryPoint.address);
+        expect(
+          await multiOwnedECDSAModule.isOwner(userSA.address, smartAccountOwner2.address)
+        ).to.be.false;
+    });
+  });
+
+  describe("validateUserOp(): ", async () => {
+    it("Returns SIG_VALIDATION_SUCCESS for a valid UserOp and valid userOpHash and allows to handle userOp", async () => {
+        const { multiOwnedECDSAModule, entryPoint, userSA, mockToken } =
+          await setupTests();
+        const userSABalanceBefore = await mockToken.balanceOf(userSA.address);
+        const eveBalanceBefore = await mockToken.balanceOf(eve.address);
+        const tokenAmountToTransfer = ethers.utils.parseEther("3.5672");
+
+        const txnData = mockToken.interface.encodeFunctionData("transfer", [
+          eve.address,
+          tokenAmountToTransfer.toString(),
+        ]);
+        const userOp = await makeEcdsaModuleUserOp(
+          "execute_ncC",
+          [mockToken.address, 0, txnData],
+          userSA.address,
+          smartAccountOwner2, //any owner can sign
+          entryPoint,
+          multiOwnedECDSAModule.address,
+          {
+            preVerificationGas: 50000,
+          }
+        );
+        // Construct userOpHash
+        const provider = entryPoint?.provider;
+        const chainId = await provider!.getNetwork().then((net) => net.chainId);
+        const userOpHash = getUserOpHash(userOp, entryPoint.address, chainId);
+
+        const res = await multiOwnedECDSAModule.validateUserOp(
+          userOp,
+          userOpHash
+        );
+        expect(res).to.be.equal(SIG_VALIDATION_SUCCESS);
+        await environment.sendUserOperation(userOp, entryPoint.address);
+        expect(await mockToken.balanceOf(eve.address)).to.equal(
+          eveBalanceBefore.add(tokenAmountToTransfer)
+        );
+        expect(await mockToken.balanceOf(userSA.address)).to.equal(
+          userSABalanceBefore.sub(tokenAmountToTransfer)
+        );
+    });
+  });
+});


### PR DESCRIPTION
# Summary

Allows having several owners, each one of them can independently sign a userOp.

[Related Issue](https://linear.app/biconomy/issue/SMA-209/multiowner-ecdsa-module-for-moralis)

## Change Type
- [ ] New Feature

# Checklist

- [ ] My code follows this project's style guidelines
- [ ] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [ ] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

# Additional Information
- Requested by Customer.
- They agreed to use it unaudited.

For the sake of saving time, only the core functionality is tested and only via Bundler (to ensure the new storage structure complies with 4337 restrictions).

❓ Need to decide do we want to audit it and release it publicly.