### PR TITLE
Features/batched session router skm verification algorithm

### DIFF
--- a/contracts/smart-account/modules/BatchedSessionRouterModule.sol
+++ b/contracts/smart-account/modules/BatchedSessionRouterModule.sol
@@ -57,8 +57,8 @@ contract BatchedSessionRouter is
             bytes memory sessionKeySignature
         ) = abi.decode(moduleSignature, (address, SessionData[], bytes));
 
-        if(!IModuleManager(userOp.sender).isModuleEnabled(sessionKeyManager)) {
-            revert ("SR Invalid SKM");
+        if (!IModuleManager(userOp.sender).isModuleEnabled(sessionKeyManager)) {
+            revert("SR Invalid SKM");
         }
 
         address recovered = ECDSA.recover(

--- a/contracts/smart-account/modules/BatchedSessionRouterModule.sol
+++ b/contracts/smart-account/modules/BatchedSessionRouterModule.sol
@@ -11,6 +11,7 @@ import {_packValidationData} from "@account-abstraction/contracts/core/Helpers.s
 import {UserOperation} from "@account-abstraction/contracts/interfaces/UserOperation.sol";
 import {IBatchedSessionRouterModule} from "../interfaces/modules/IBatchedSessionRouterModule.sol";
 import {IAuthorizationModule} from "../interfaces/IAuthorizationModule.sol";
+import {IModuleManager} from "../interfaces/base/IModuleManager.sol";
 
 /**
  * @title Batched Session Router
@@ -56,10 +57,12 @@ contract BatchedSessionRouter is
             bytes memory sessionKeySignature
         ) = abi.decode(moduleSignature, (address, SessionData[], bytes));
 
+        if(!IModuleManager(userOp.sender).isModuleEnabled(sessionKeyManager)) {
+            revert ("SR Invalid SKM");
+        }
+
         address recovered = ECDSA.recover(
-            ECDSA.toEthSignedMessageHash(
-                keccak256(abi.encodePacked(userOpHash, sessionKeyManager))
-            ),
+            ECDSA.toEthSignedMessageHash(userOpHash),
             sessionKeySignature
         );
 

--- a/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
+++ b/contracts/smart-account/modules/MultiOwnedECDSAModule.sol
@@ -99,7 +99,7 @@ contract MultiOwnedECDSAModule is
             revert NotAnOwner(owner, msg.sender);
         _transferOwnership(msg.sender, owner, address(0));
         unchecked {
-            --numberOfOwners[msg.sender];   
+            --numberOfOwners[msg.sender];
         }
     }
 

--- a/contracts/smart-account/modules/PasskeyRegistryModule.sol
+++ b/contracts/smart-account/modules/PasskeyRegistryModule.sol
@@ -36,7 +36,7 @@ contract PasskeyRegistryModule is
         PassKeyId storage passKeyId = smartAccountPassKeys[msg.sender];
 
         if (passKeyId.pubKeyX != 0 && passKeyId.pubKeyY != 0)
-        revert AlreadyInitedForSmartAccount(msg.sender);
+            revert AlreadyInitedForSmartAccount(msg.sender);
 
         smartAccountPassKeys[msg.sender] = PassKeyId(
             _pubKeyX,

--- a/test/bundler-integration/module/BatchedSessionRouter.Module.specs.ts
+++ b/test/bundler-integration/module/BatchedSessionRouter.Module.specs.ts
@@ -16,7 +16,7 @@ import {
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BundlerTestEnvironment } from "../environment/bundlerEnvironment";
 
-describe("SessionKey: Session Router (via Bundler)", async () => {
+describe("SessionKey: Batched Session Router (via Bundler)", async () => {
   let [deployer, smartAccountOwner, charlie, verifiedSigner, sessionKey] =
     [] as SignerWithAddress[];
 
@@ -233,13 +233,8 @@ describe("SessionKey: Session Router (via Bundler)", async () => {
 
     // create a signature with the sessionKeyManager address
     const userOpHash = await entryPoint.getUserOpHash(userOp);
-    const userOpHashAndModuleAddress = ethers.utils.hexConcat([
-      ethers.utils.hexZeroPad(userOpHash, 32),
-      ethers.utils.hexZeroPad(sessionKeyManager.address, 20),
-    ]);
-    const resultingHash = ethers.utils.keccak256(userOpHashAndModuleAddress);
-    const signatureOverUserOpHashAndModuleAddress =
-      await sessionKey.signMessage(ethers.utils.arrayify(resultingHash));
+    const signatureOverUserOpHash =
+      await sessionKey.signMessage(ethers.utils.arrayify(userOpHash));
 
     const paddedSig = ethers.utils.defaultAbiCoder.encode(
       [
@@ -267,7 +262,7 @@ describe("SessionKey: Session Router (via Bundler)", async () => {
             "0x",
           ],
         ],
-        signatureOverUserOpHashAndModuleAddress,
+        signatureOverUserOpHash,
       ]
     );
 

--- a/test/bundler-integration/module/BatchedSessionRouter.Module.specs.ts
+++ b/test/bundler-integration/module/BatchedSessionRouter.Module.specs.ts
@@ -233,8 +233,9 @@ describe("SessionKey: Batched Session Router (via Bundler)", async () => {
 
     // create a signature with the sessionKeyManager address
     const userOpHash = await entryPoint.getUserOpHash(userOp);
-    const signatureOverUserOpHash =
-      await sessionKey.signMessage(ethers.utils.arrayify(userOpHash));
+    const signatureOverUserOpHash = await sessionKey.signMessage(
+      ethers.utils.arrayify(userOpHash)
+    );
 
     const paddedSig = ethers.utils.defaultAbiCoder.encode(
       [

--- a/test/module/BatchedSessionRouter.Module.specs.ts
+++ b/test/module/BatchedSessionRouter.Module.specs.ts
@@ -864,7 +864,7 @@ describe("SessionKey: Batched Session Router", async () => {
       sessionKeyData2,
       leafData2,
       validUntilForMockProtocol,
-      erc20SessionModule
+      erc20SessionModule,
     } = await setupTests();
     const tokenAmountToTransfer = ethers.utils.parseEther("1.7534");
 
@@ -1250,11 +1250,7 @@ describe("SessionKey: Batched Session Router", async () => {
           "tuple(uint48,uint48,address,bytes,bytes32[],bytes)[]",
           "bytes",
         ],
-        [
-          sessionKeyManager.address,
-          sessionData,
-          signatureOverUserOpHash,
-        ]
+        [sessionKeyManager.address, sessionData, signatureOverUserOpHash]
       );
 
       const signatureWithModuleAddress = ethers.utils.defaultAbiCoder.encode(

--- a/test/module/BatchedSessionRouter.Module.specs.ts
+++ b/test/module/BatchedSessionRouter.Module.specs.ts
@@ -15,6 +15,7 @@ import {
   getSmartAccountWithModule,
 } from "../utils/setupHelper";
 import { computeAddress, defaultAbiCoder } from "ethers/lib/utils";
+import { ERC20SessionValidationModule } from "../../typechain";
 
 describe("SessionKey: Batched Session Router", async () => {
   const [deployer, smartAccountOwner, alice, sessionKey, nonAuthSessionKey] =
@@ -271,24 +272,14 @@ describe("SessionKey: Batched Session Router", async () => {
       "nonce"
     );
 
-    // create a signature with the sessionKeyManager address
-    const userOpHash = await entryPoint.getUserOpHash(userOp);
-    const userOpHashAndModuleAddress = ethers.utils.hexConcat([
-      ethers.utils.hexZeroPad(userOpHash, 32),
-      ethers.utils.hexZeroPad(sessionKeyManager.address, 20),
-    ]);
-    const resultingHash = ethers.utils.keccak256(userOpHashAndModuleAddress);
-    const signatureOverUserOpHashAndModuleAddress =
-      await sessionKey.signMessage(ethers.utils.arrayify(resultingHash));
-
     const paddedSig = ethers.utils.defaultAbiCoder.encode(
       [
-        "uint256", // uint256 instead of address
+        "address",
         "tuple(uint48,uint48,address,bytes,bytes32[],bytes)[]",
-        "bytes",
+        "uint256",
       ],
       [
-        0,
+        sessionKeyManager.address,
         [
           [
             0,
@@ -307,7 +298,7 @@ describe("SessionKey: Batched Session Router", async () => {
             "0x",
           ],
         ],
-        signatureOverUserOpHashAndModuleAddress,
+        111,
       ]
     );
 
@@ -858,6 +849,80 @@ describe("SessionKey: Batched Session Router", async () => {
       .withArgs(0, "AA23 reverted: SessionNotApproved");
   });
 
+  it("should revert if Session Key Manager address provided in the sig is wrong", async () => {
+    const {
+      entryPoint,
+      userSA,
+      sessionKeyManager,
+      sessionKeyData,
+      leafData,
+      merkleTree,
+      sessionRouter,
+      mockProtocol,
+      mockProtocolSVM,
+      mockToken,
+      sessionKeyData2,
+      leafData2,
+      validUntilForMockProtocol,
+      erc20SessionModule
+    } = await setupTests();
+    const tokenAmountToTransfer = ethers.utils.parseEther("1.7534");
+
+    const MockProtocol = await ethers.getContractFactory("MockProtocol");
+    const IERC20 = await ethers.getContractFactory("ERC20");
+
+    const approveCallData = IERC20.interface.encodeFunctionData("approve", [
+      mockProtocol.address,
+      tokenAmountToTransfer,
+    ]);
+    const interactCallData = MockProtocol.interface.encodeFunctionData(
+      "interact",
+      [mockToken.address, tokenAmountToTransfer]
+    );
+
+    const wrongSessionKeyManagerAddress = computeAddress(
+      ethers.utils.randomBytes(32)
+    );
+
+    const userOp = await makeEcdsaSessionKeySignedBatchUserOp(
+      "executeBatch_y6U",
+      [
+        [mockToken.address, mockProtocol.address],
+        [0, 0],
+        [approveCallData, interactCallData],
+      ],
+      userSA.address,
+      sessionKey,
+      entryPoint,
+      wrongSessionKeyManagerAddress,
+      [
+        [
+          0,
+          0,
+          erc20SessionModule.address,
+          sessionKeyData,
+          merkleTree.getHexProof(ethers.utils.keccak256(leafData)),
+          "0x",
+        ],
+        [
+          validUntilForMockProtocol,
+          0,
+          mockProtocolSVM.address,
+          sessionKeyData2,
+          merkleTree.getHexProof(ethers.utils.keccak256(leafData2)),
+          "0x",
+        ],
+      ],
+      sessionRouter.address
+    );
+
+    await expect(
+      entryPoint.handleOps([userOp], alice.address, { gasLimit: 10000000 })
+    )
+      .to.be.revertedWith("FailedOp")
+      .withArgs(0, "AA23 reverted: SR Invalid SKM");
+  });
+
   it("should revert if session key data provided in the sig is wrong", async () => {
     const {
       entryPoint,
@@ -1134,40 +1199,6 @@ describe("SessionKey: Batched Session Router", async () => {
         [mockToken.address, tokenAmountToTransfer]
       );
 
-      /*
-      const userOp = await makeEcdsaSessionKeySignedBatchUserOp(
-        "executeBatch_y6U",
-        [
-          [mockToken.address, mockProtocol.address],
-          [0, 0],
-          [approveCallData, interactCallData],
-        ],
-        userSA.address,
-        sessionKey,
-        entryPoint,
-        sessionKeyManager.address,
-        [
-          [
-            0,
-            0,
-            erc20SessionModule.address,
-            sessionKeyData,
-            merkleTree.getHexProof(ethers.utils.keccak256(leafData)),
-            "0x",
-          ],
-          [
-            validUntilForMockProtocol,
-            0,
-            mockProtocolSVM.address,
-            sessionKeyData2,
-            merkleTree.getHexProof(ethers.utils.keccak256(leafData2)),
-            "0x",
-          ],
-        ],
-        sessionRouter.address
-      );
-      */
-
       const SmartAccount = await ethers.getContractFactory("SmartAccount");
 
       const txnDataAA1 = SmartAccount.interface.encodeFunctionData(
@@ -1190,13 +1221,8 @@ describe("SessionKey: Batched Session Router", async () => {
       );
 
       const userOpHash = await entryPoint.getUserOpHash(userOp);
-      const userOpHashAndModuleAddress = ethers.utils.hexConcat([
-        ethers.utils.hexZeroPad(userOpHash, 32),
-        ethers.utils.hexZeroPad(sessionKeyManager.address, 20),
-      ]);
-      const resultingHash = ethers.utils.keccak256(userOpHashAndModuleAddress);
-      const signatureOverUserOpHashAndModuleAddress = (
-        await sessionKey.signMessage(ethers.utils.arrayify(resultingHash))
+      const signatureOverUserOpHash = (
+        await sessionKey.signMessage(ethers.utils.arrayify(userOpHash))
       ).slice(0, -2);
 
       const sessionData = [
@@ -1227,7 +1253,7 @@ describe("SessionKey: Batched Session Router", async () => {
         [
           sessionKeyManager.address,
           sessionData,
-          signatureOverUserOpHashAndModuleAddress,
+          signatureOverUserOpHash,
         ]
       );
 

--- a/test/utils/sessionKey.ts
+++ b/test/utils/sessionKey.ts
@@ -44,13 +44,8 @@ export async function makeEcdsaSessionKeySignedBatchUserOp(
   );
 
   const userOpHash = await entryPoint.getUserOpHash(userOp);
-  const userOpHashAndModuleAddress = ethers.utils.hexConcat([
-    ethers.utils.hexZeroPad(userOpHash, 32),
-    ethers.utils.hexZeroPad(sessionKeyManagerAddress, 20),
-  ]);
-  const resultingHash = ethers.utils.keccak256(userOpHashAndModuleAddress);
   const signatureOverUserOpHashAndModuleAddress = await sessionKey.signMessage(
-    ethers.utils.arrayify(resultingHash)
+    ethers.utils.arrayify(userOpHash)
   );
 
   const paddedSig = defaultAbiCoder.encode(


### PR DESCRIPTION
# Summary

Changed the way Batched Session Router checks the appropriate Session Key Manager was provided in the signature.
Now BSR checks that the SKM address provided is enabled for this SA using `isModuleEnabled`.

## Change Type

- [ ] Bug Fix

# Checklist

- [ ] My code follows this project's style guidelines
- [ ] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [ ] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published