### PR TITLE
SMA-316: Remove dependence on via-ir for compilation

### DIFF
--- a/contracts/smart-account/modules/BatchedSessionRouterModule.sol
+++ b/contracts/smart-account/modules/BatchedSessionRouterModule.sol
@@ -37,34 +37,46 @@ contract BatchedSessionRouter is
         UserOperation calldata userOp,
         bytes32 userOpHash
     ) external virtual override returns (uint256) {
-        // check this is a proper method call
-        bytes4 selector = bytes4(userOp.callData[0:4]);
-        require(
-            selector == EXECUTE_BATCH_OPTIMIZED_SELECTOR ||
-                selector == EXECUTE_BATCH_SELECTOR,
-            "SR Invalid Selector"
-        );
-
-        (bytes memory moduleSignature, ) = abi.decode(
-            userOp.signature,
-            (bytes, address)
-        );
-
-        // parse the signature to get the array of required parameters
-        (
-            address sessionKeyManager,
-            SessionData[] memory sessionData,
-            bytes memory sessionKeySignature
-        ) = abi.decode(moduleSignature, (address, SessionData[], bytes));
-
-        if (!IModuleManager(userOp.sender).isModuleEnabled(sessionKeyManager)) {
-            revert("SR Invalid SKM");
+        {
+            // check this is a proper method call
+            bytes4 selector = bytes4(userOp.callData[0:4]);
+            require(
+                selector == EXECUTE_BATCH_OPTIMIZED_SELECTOR ||
+                    selector == EXECUTE_BATCH_SELECTOR,
+                "SR Invalid Selector"
+            );
         }
 
-        address recovered = ECDSA.recover(
-            ECDSA.toEthSignedMessageHash(userOpHash),
-            sessionKeySignature
-        );
+        address sessionKeyManager;
+        SessionData[] memory sessionData;
+        address recovered;
+        {
+            bytes memory sessionKeySignature;
+
+            {
+                (bytes memory moduleSignature, ) = abi.decode(
+                    userOp.signature,
+                    (bytes, address)
+                );
+
+                // parse the signature to get the array of required parameters
+                (sessionKeyManager, sessionData, sessionKeySignature) = abi
+                    .decode(moduleSignature, (address, SessionData[], bytes));
+            }
+
+            if (
+                !IModuleManager(userOp.sender).isModuleEnabled(
+                    sessionKeyManager
+                )
+            ) {
+                revert("SR Invalid SKM");
+            }
+
+            recovered = ECDSA.recover(
+                ECDSA.toEthSignedMessageHash(userOpHash),
+                sessionKeySignature
+            );
+        }
 
         uint48 earliestValidUntil = type(uint48).max;
         uint48 latestValidAfter;

--- a/contracts/smart-account/modules/SessionValidationModules/ERC20SessionValidationModule.sol
+++ b/contracts/smart-account/modules/SessionValidationModules/ERC20SessionValidationModule.sol
@@ -71,50 +71,59 @@ contract ERC20SessionValidationModule is ISessionValidationModule {
                 bytes4(_op.callData[0:4]) == EXECUTE_SELECTOR,
             "ERC20SV Invalid Selector"
         );
-        (
-            address sessionKey,
-            address token,
-            address recipient,
-            uint256 maxAmount
-        ) = abi.decode(_sessionKeyData, (address, address, address, uint256));
+
+        address sessionKey;
 
         {
-            // we expect _op.callData to be `SmartAccount.execute(to, value, calldata)` calldata
-            (address tokenAddr, uint256 callValue, ) = abi.decode(
-                _op.callData[4:], // skip selector
-                (address, uint256, bytes)
-            );
-            if (tokenAddr != token) {
-                revert("ERC20SV Wrong Token");
+            (
+                address innerSessionKey,
+                address token,
+                address recipient,
+                uint256 maxAmount
+            ) = abi.decode(
+                    _sessionKeyData,
+                    (address, address, address, uint256)
+                );
+            sessionKey = innerSessionKey;
+
+            {
+                // we expect _op.callData to be `SmartAccount.execute(to, value, calldata)` calldata
+                (address tokenAddr, uint256 callValue, ) = abi.decode(
+                    _op.callData[4:], // skip selector
+                    (address, uint256, bytes)
+                );
+                if (tokenAddr != token) {
+                    revert("ERC20SV Wrong Token");
+                }
+                if (callValue != 0) {
+                    revert("ERC20SV Non Zero Value");
+                }
             }
-            if (callValue != 0) {
-                revert("ERC20SV Non Zero Value");
+            // working with userOp.callData
+            // check if the call is to the allowed recepient and amount is not more than allowed
+            bytes calldata data;
+
+            {
+                //offset represents where does the inner bytes array start
+                uint256 offset = uint256(bytes32(_op.callData[4 + 64:4 + 96]));
+                uint256 length = uint256(
+                    bytes32(_op.callData[4 + offset:4 + offset + 32])
+                );
+                //we expect data to be the `IERC20.transfer(address, uint256)` calldata
+                data = _op.callData[4 + offset + 32:4 + offset + 32 + length];
             }
-        }
-        // working with userOp.callData
-        // check if the call is to the allowed recepient and amount is not more than allowed
-        bytes calldata data;
 
-        {
-            //offset represents where does the inner bytes array start
-            uint256 offset = uint256(bytes32(_op.callData[4 + 64:4 + 96]));
-            uint256 length = uint256(
-                bytes32(_op.callData[4 + offset:4 + offset + 32])
+            (address recipientCalled, uint256 amount) = abi.decode(
+                data[4:],
+                (address, uint256)
             );
-            //we expect data to be the `IERC20.transfer(address, uint256)` calldata
-            data = _op.callData[4 + offset + 32:4 + offset + 32 + length];
-        }
 
-        (address recipientCalled, uint256 amount) = abi.decode(
-            data[4:],
-            (address, uint256)
-        );
-
-        if (recipientCalled != recipient) {
-            revert("ERC20SV Wrong Recipient");
-        }
-        if (amount > maxAmount) {
-            revert("ERC20SV Max Amount Exceeded");
+            if (recipientCalled != recipient) {
+                revert("ERC20SV Wrong Recipient");
+            }
+            if (amount > maxAmount) {
+                revert("ERC20SV Max Amount Exceeded");
+            }
         }
 
         return

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,6 +12,6 @@ remappings = [
     "hardhat-deploy/=node_modules/hardhat-deploy/",
     "hardhat/=node_modules/hardhat/",
 ]
-via_ir = true
+via_ir = false
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
# Summary

While we'll still use via-ir while deploying contracts, having contracts that do not require via-ir to be compiled enables the coverage-tracking plugins to work properly.
I've made very simple modifications that should in theory not affect the gas consumed by these contracts. But still to be on the safe side, what would be the best way to measure gas (before and after) for the updated modules? @filmakarov 

## Change Type

- [ ] Bug Fix
- [x] Refactor
- [ ] New Feature
- [ ] Breaking Change
- [ ] Documentation Update
- [ ] Performance Improvement
- [x] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [x] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
