### PR TITLE
Add event for updating merkle root at Session Key Manager

### DIFF
--- a/contracts/smart-account/interfaces/modules/ISessionKeyManagerModule.sol
+++ b/contracts/smart-account/interfaces/modules/ISessionKeyManagerModule.sol
@@ -18,6 +18,12 @@ interface ISessionKeyManagerModule {
     }
 
     /**
+     * @dev Emitted when the merkle root is updated for the Smart Account
+     * It happens when there's a need to add\remove\replace session (leaves) in the Merkle Tree
+     */
+    event MerkleRootUpdated(address smartAccount, bytes32 newRoot);
+
+    /**
      * @dev validates that Session Key + parameters are enabled
      * by being included into the merkle tree
      * @param userOpSender smartAccount for which session key is being validated

--- a/contracts/smart-account/modules/SessionKeyManagerModule.sol
+++ b/contracts/smart-account/modules/SessionKeyManagerModule.sol
@@ -35,7 +35,7 @@ contract SessionKeyManager is
     /// @inheritdoc ISessionKeyManagerModule
     function setMerkleRoot(bytes32 _merkleRoot) external override {
         _userSessions[msg.sender].merkleRoot = _merkleRoot;
-        // TODO:should we add an event here? which emits the new merkle root
+        emit MerkleRootUpdated(msg.sender, _merkleRoot);
     }
 
     /// @inheritdoc IAuthorizationModule


### PR DESCRIPTION
# Summary

Add event for updating merkle root at Session Key Manager. It will allow Data squad to easily track when the first session was enabled for the SA

Related Issue: [SMA-330](https://linear.app/biconomy/issue/SMA-330/add-event-on-setting-merkle-root-in-the-skm)

## Change Type
- [x] Other

# Checklist

- [x] My code follows this project's style guidelines
- [x] I've reviewed my own code
- [x] I've added comments for any hard-to-understand areas
- [x] I've updated the documentation if necessary
- [x] My changes generate no new warnings
- [x] I've added tests that prove my fix is effective or my feature works
- [x] All unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

# Additional Information
<!-- Any additional information or context about the PR. -->