### PR TITLE
SMA-146 Only Module Removal Check

### DIFF
--- a/contracts/smart-account/base/ModuleManager.sol
+++ b/contracts/smart-account/base/ModuleManager.sol
@@ -217,6 +217,8 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         if (module == address(0) || module == SENTINEL_MODULES) {
             revert ModuleCannotBeZeroOrSentinel(module);
         }
+        if (_modules[module] == SENTINEL_MODULES && _modules[SENTINEL_MODULES] == module)
+            revert CanNotDisableOnlyModule(module);
         if (_modules[prevModule] != module) {
             revert ModuleAndPrevModuleMismatch(
                 module,

--- a/contracts/smart-account/base/ModuleManager.sol
+++ b/contracts/smart-account/base/ModuleManager.sol
@@ -217,8 +217,10 @@ abstract contract ModuleManager is SelfAuthorized, Executor, IModuleManager {
         if (module == address(0) || module == SENTINEL_MODULES) {
             revert ModuleCannotBeZeroOrSentinel(module);
         }
-        if (_modules[module] == SENTINEL_MODULES && _modules[SENTINEL_MODULES] == module)
-            revert CanNotDisableOnlyModule(module);
+        if (
+            _modules[module] == SENTINEL_MODULES &&
+            _modules[SENTINEL_MODULES] == module
+        ) revert CanNotDisableOnlyModule(module);
         if (_modules[prevModule] != module) {
             revert ModuleAndPrevModuleMismatch(
                 module,

--- a/contracts/smart-account/interfaces/base/IModuleManager.sol
+++ b/contracts/smart-account/interfaces/base/IModuleManager.sol
@@ -77,6 +77,12 @@ interface IModuleManager {
     );
 
     /**
+     * @notice Throws when trying to remove the only enabled module
+     * @param module Module address provided
+     */
+    error CanNotDisableOnlyModule(address module);
+
+    /**
      * @dev Adds a module to the allowlist.
      * @notice This SHOULD only be done via userOp or a selfcall.
      */

--- a/test/smart-account/SA.Modules.specs.ts
+++ b/test/smart-account/SA.Modules.specs.ts
@@ -55,7 +55,7 @@ describe("Modular Smart Account Modules: ", async () => {
       mockToken: mockToken,
       ecdsaModule: ecdsaModule,
       userSA: userSA,
-      chainId: chainId, 
+      chainId: chainId,
     };
   });
 
@@ -289,16 +289,15 @@ describe("Modular Smart Account Modules: ", async () => {
       ]);
 
       const tx = await entryPoint.handleOps([userOp], alice.address);
-      await expect(tx).to.emit(entryPoint, "UserOperationRevertReason")
+      await expect(tx)
+        .to.emit(entryPoint, "UserOperationRevertReason")
         .withArgs(
           getUserOpHash(userOp, entryPoint.address, chainId),
           userOp.sender,
           userOp.nonce,
           errorData
         );
-      expect(await userSA.isModuleEnabled(ecdsaModule.address)).to.equal(
-        true
-      );
+      expect(await userSA.isModuleEnabled(ecdsaModule.address)).to.equal(true);
     });
   });
 


### PR DESCRIPTION
# Summary

Added the check to not allow removing the only enabled module

Related Issue: [#SMA-146](https://linear.app/biconomy/issue/SMA-146/implement-check-to-prevent-removal-of-last-module)

## Change Type

- [ ] Other

# Checklist

- [ ] My code follows this project's style guidelines
- [ ] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [ ] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published