### PR TITLE
correct critical vuln on null signature

### DIFF
--- a/contracts/smart-account/modules/PasskeyValidationModules/Secp256r1.sol
+++ b/contracts/smart-account/modules/PasskeyValidationModules/Secp256r1.sol
@@ -52,7 +52,10 @@ library Secp256r1 {
         uint256 s,
         uint256 e
     ) internal view returns (bool) {
-        if (r >= NN || s >= NN) {
+           //test potential null signature, as spoted in https://github.com/itsobvioustech/aa-passkeys-wallet/blob/6e449fd05bf127e6447c5603e454c900720298fd/src/Secp256r1.sol#L46
+        if (r==0 ||r >= NN ||s==0|| s >= NN) {
+            return false;
+        }
             return false;
         }
 
@@ -66,7 +69,8 @@ library Secp256r1 {
         uint256 s,
         uint256 e
     ) internal view returns (bool) {
-        if (r >= NN || s >= NN) {
+           //test potential null signature, as spoted in https://github.com/itsobvioustech/aa-passkeys-wallet/blob/6e449fd05bf127e6447c5603e454c900720298fd/src/Secp256r1.sol#L46
+        if (r==0 ||r >= NN ||s==0|| s >= NN) {
             return false;
         }
 


### PR DESCRIPTION
Correct null signature bug, as spoted in
https://eprint.iacr.org/2023/939.pdf

# Summary
The current P256 implementation enables a null signature to be valid for any message.
This is the highest critical severity.

Related Issue: 207

https://github.com/bcnmy/scw-contracts/issues/207

## Change Type

- [x] Bug Fix

# Additional Information

This library contains additional issues. As a potential 

# Branch Naming
